### PR TITLE
refactor(frontend): 重構 App.vue 並解耦為 composables 架構

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kiro Manager
 
-> 跨平台 Kiro IDE 管理工具 | v0.6.0
+> 跨平台 Kiro IDE 管理工具 | v0.6.1
 
 一款基於 Wails + Vue 3 的桌面應用程式，提供 Kiro IDE 的帳號管理、Machine ID 備份與恢復、一鍵新機等功能。
 

--- a/app.go
+++ b/app.go
@@ -548,7 +548,7 @@ func (a *App) IsDeepLinkSupported() bool {
 // GetAppInfo 取得應用資訊
 func (a *App) GetAppInfo() map[string]string {
 	return map[string]string{
-		"version":   "0.6.0",
+		"version":   "0.6.1",
 		"platform":  runtime.GOOS,
 		"buildTime": time.Now().Format("2025-12-07"),
 	}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kiro-manager-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@number-flow/vue": "^0.4.9",
         "vue": "^3.4.0",
         "vue-i18n": "^9.9.0"
       },
@@ -635,6 +636,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@number-flow/vue": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@number-flow/vue/-/vue-0.4.9.tgz",
+      "integrity": "sha512-K1E0ZMj7So66kbo5BD4rdqIwpIWt1sqAY5r9B/N8Np8b2ejcJHGmKs+7vQXuXDccQjP5zqsbe/+oDV6QgTWGyg==",
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.1.4",
+        "number-flow": "0.5.9"
+      },
+      "peerDependencies": {
+        "vue": "^3"
       }
     },
     "node_modules/@one-ini/wasm": {
@@ -1791,6 +1805,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "license": "MIT"
@@ -1887,7 +1907,7 @@
         "darwin"
       ],
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": "^8.16.0 || ^10.6.1 || >=11.0.0"
       }
     },
     "node_modules/glob": {
@@ -2156,6 +2176,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/number-flow": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/number-flow/-/number-flow-0.5.9.tgz",
+      "integrity": "sha512-o3102c/4qRd6eV4n+rw6B/UP8+FosbhIxj4uA6GsjhryrGZRVtCtKIKEeBiOwUV52cUGJneeu0treELcV7U/lw==",
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.1.4"
       }
     },
     "node_modules/obug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@number-flow/vue": "^0.4.9",
     "vue": "^3.4.0",
     "vue-i18n": "^9.9.0"
   },

--- a/frontend/src/components/BackupCard.vue
+++ b/frontend/src/components/BackupCard.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+/**
+ * BackupCard 組件
+ * @description 顯示單一備份的資訊和操作按鈕
+ * @requirements 6.1-12.3
+ */
+import { computed } from 'vue'
+import Icon from './Icon.vue'
+import NumberFlow from './NumberFlow.vue'
+import { getSubscriptionColorClass, getSubscriptionShortName } from '../utils/subscription'
+import { truncateMachineId } from '../utils/machineId'
+
+// ============================================================================
+// Props 定義
+// ============================================================================
+
+interface BackupData {
+  name: string
+  provider: string
+  subscriptionTitle: string
+  usageLimit: number
+  currentUsage: number
+  balance: number
+  isLowBalance: boolean
+  isCurrent: boolean
+  isOriginalMachine: boolean
+  machineId: string
+  isTokenExpired?: boolean
+}
+
+interface Props {
+  backup: BackupData
+  isSelected: boolean
+  isSwitching: boolean
+  isDeleting: boolean
+  isRefreshing: boolean
+  isRegenerating: boolean
+  cooldownSeconds: number
+  copiedMachineId: string | null
+}
+
+const props = defineProps<Props>()
+
+// ============================================================================
+// Events 定義
+// ============================================================================
+
+const emit = defineEmits<{
+  (e: 'select', name: string): void
+  (e: 'switch', name: string): void
+  (e: 'delete', name: string): void
+  (e: 'refresh', name: string): void
+  (e: 'regenerate-id', name: string): void
+  (e: 'copy-machine-id', machineId: string): void
+  (e: 'drag-start', event: DragEvent, name: string): void
+  (e: 'drag-end', event: DragEvent): void
+}>()
+
+// ============================================================================
+// 計算屬性
+// ============================================================================
+
+const isInCooldown = computed(() => props.cooldownSeconds > 0)
+
+const isCopied = computed(() => props.copiedMachineId === props.backup.machineId)
+
+const displayMachineId = computed(() => truncateMachineId(props.backup.machineId))
+
+const subscriptionClass = computed(() => getSubscriptionColorClass(props.backup.subscriptionTitle))
+
+const subscriptionShortName = computed(() => getSubscriptionShortName(props.backup.subscriptionTitle))
+
+// ============================================================================
+// 事件處理
+// ============================================================================
+
+const handleSelect = () => {
+  emit('select', props.backup.name)
+}
+
+const handleSwitch = () => {
+  emit('switch', props.backup.name)
+}
+
+const handleDelete = () => {
+  emit('delete', props.backup.name)
+}
+
+const handleRefresh = () => {
+  if (!isInCooldown.value) {
+    emit('refresh', props.backup.name)
+  }
+}
+
+const handleRegenerate = () => {
+  emit('regenerate-id', props.backup.name)
+}
+
+const handleCopyMachineId = () => {
+  if (props.backup.machineId) {
+    emit('copy-machine-id', props.backup.machineId)
+  }
+}
+
+const handleDragStart = (event: DragEvent) => {
+  emit('drag-start', event, props.backup.name)
+}
+
+const handleDragEnd = (event: DragEvent) => {
+  emit('drag-end', event)
+}
+</script>
+
+<template>
+  <div
+    draggable="true"
+    @dragstart="handleDragStart"
+    @dragend="handleDragEnd"
+    :class="[
+      'flex items-center px-4 py-3 group transition-colors cursor-move',
+      backup.isCurrent ? 'bg-app-accent/5' : 'hover:bg-zinc-800/30'
+    ]"
+  >
+    <!-- Checkbox -->
+    <div class="w-8 flex-shrink-0">
+      <input
+        type="checkbox"
+        :checked="isSelected"
+        @change="handleSelect"
+        class="custom-checkbox"
+      />
+    </div>
+
+    <!-- 快照名稱 -->
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center">
+        <Icon name="GripVertical" class="w-4 h-4 text-zinc-600 mr-2 opacity-0 group-hover:opacity-100 transition-opacity" />
+        
+        <!-- 活躍狀態指示器 -->
+        <div
+          v-if="backup.isCurrent"
+          data-testid="active-indicator"
+          class="w-1.5 h-1.5 rounded-full bg-app-warning mr-2 shadow-[0_0_8px_rgba(245,158,11,0.8)]"
+        ></div>
+        
+        <span :class="['font-medium truncate', backup.isCurrent ? 'text-white' : 'text-zinc-400']">
+          {{ backup.name }}
+        </span>
+        
+        <!-- 原始機器標籤 -->
+        <span
+          v-if="backup.isOriginalMachine"
+          data-testid="original-machine-label"
+          class="ml-2 px-1.5 py-0.5 rounded text-[10px] bg-app-accent/20 text-app-accent border border-app-accent/30"
+        >
+          Original
+        </span>
+      </div>
+    </div>
+
+    <!-- Provider -->
+    <div class="w-24 flex-shrink-0 px-2 flex justify-center">
+      <span class="px-2 py-1 rounded text-[10px] bg-zinc-800 text-zinc-400 border border-zinc-700 inline-flex items-center gap-1">
+        <span data-testid="provider-icon">
+          <Icon v-if="backup.provider === 'Github'" name="Github" class="w-3 h-3" />
+          <Icon v-else-if="backup.provider === 'AWS' || backup.provider === 'BuilderId'" name="AWS" class="w-3 h-3" />
+          <Icon v-else-if="backup.provider === 'Enterprise'" name="AWS" class="w-3 h-3" />
+          <Icon v-else-if="backup.provider === 'Google'" name="Google" class="w-3 h-3" />
+        </span>
+        {{ backup.provider }}
+      </span>
+    </div>
+
+    <!-- 訂閱類型 -->
+    <div class="w-16 flex-shrink-0 px-2">
+      <span
+        v-if="backup.subscriptionTitle"
+        :class="['px-2 py-0.5 rounded text-[10px] font-medium', subscriptionClass]"
+      >
+        {{ subscriptionShortName }}
+      </span>
+      <span v-else class="text-zinc-500 text-xs">-</span>
+    </div>
+
+    <!-- 餘額 -->
+    <div class="w-36 flex-shrink-0 px-2 flex items-center justify-end gap-2">
+      <span
+        v-if="backup.usageLimit > 0"
+        data-testid="balance"
+        :class="['font-mono text-xs whitespace-nowrap', backup.isLowBalance ? 'text-app-warning' : 'text-zinc-400']"
+      >
+        <NumberFlow :value="Math.round(backup.balance)" />/<NumberFlow :value="Math.round(backup.usageLimit)" />
+      </span>
+      <span v-else class="text-zinc-500 text-xs">-</span>
+      
+      <!-- 刷新按鈕 -->
+      <button
+        data-testid="refresh-btn"
+        @click.stop="handleRefresh"
+        :disabled="isInCooldown"
+        class="p-0.5 text-zinc-500 hover:text-zinc-300 transition-colors disabled:cursor-not-allowed"
+        :title="backup.isTokenExpired ? 'Token expired' : 'Refresh usage'"
+      >
+        <!-- 倒計時數字 -->
+        <span v-if="isInCooldown" class="text-xs font-mono text-zinc-500 w-4 inline-block text-center">
+          <NumberFlow :value="cooldownSeconds" />
+        </span>
+        <!-- 刷新圖標 -->
+        <Icon
+          v-else
+          name="RefreshCw"
+          :class="['w-3 h-3', isRefreshing ? 'animate-spin' : '']"
+        />
+      </button>
+    </div>
+
+    <!-- Machine ID -->
+    <div class="w-32 flex-shrink-0 px-2">
+      <button
+        v-if="backup.machineId"
+        data-testid="machine-id-btn"
+        @click="handleCopyMachineId"
+        class="font-mono text-[10px] text-zinc-500 hover:text-zinc-300 cursor-pointer transition-colors inline-flex items-center gap-1 group"
+        :title="backup.machineId"
+      >
+        <span>{{ displayMachineId }}</span>
+        <Icon
+          :name="isCopied ? 'Check' : 'Copy'"
+          :class="[
+            'w-3 h-3 transition-all',
+            isCopied
+              ? 'text-app-success'
+              : 'opacity-0 group-hover:opacity-100 text-zinc-400'
+          ]"
+        />
+      </button>
+      <span v-else class="font-mono text-[10px] text-zinc-500">-</span>
+    </div>
+
+    <!-- 操作按鈕 -->
+    <div class="w-28 flex-shrink-0 flex justify-end gap-1">
+      <!-- 切換按鈕 (非當前備份時顯示) -->
+      <button
+        v-if="!backup.isCurrent"
+        data-testid="switch-btn"
+        @click="handleSwitch"
+        :disabled="isSwitching"
+        :class="[
+          'p-1.5 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700/50 rounded transition-colors',
+          isSwitching ? 'animate-bounce' : ''
+        ]"
+        title="Switch to this backup"
+      >
+        <Icon name="Download" class="w-3.5 h-3.5" />
+      </button>
+      
+      <!-- 重新生成機器碼按鈕 (非當前備份時顯示) -->
+      <button
+        v-if="!backup.isCurrent"
+        data-testid="regenerate-btn"
+        @click="handleRegenerate"
+        :disabled="isRegenerating"
+        :class="[
+          'p-1.5 text-zinc-500 hover:text-app-accent hover:bg-zinc-700/50 rounded transition-colors',
+          isRegenerating ? 'animate-pulse-fast' : ''
+        ]"
+        title="Regenerate machine ID"
+      >
+        <Icon name="Key" class="w-3.5 h-3.5" />
+      </button>
+      
+      <!-- 刪除按鈕 (非當前備份時顯示) -->
+      <button
+        v-if="!backup.isCurrent"
+        data-testid="delete-btn"
+        @click="handleDelete"
+        :disabled="isDeleting"
+        :class="[
+          'p-1.5 text-zinc-500 hover:text-red-400 hover:bg-zinc-700/50 rounded transition-colors',
+          isDeleting ? 'animate-pulse' : ''
+        ]"
+        title="Delete backup"
+      >
+        <Icon name="Trash" class="w-3.5 h-3.5" />
+      </button>
+      
+      <!-- 活躍狀態標籤 (當前備份時顯示) -->
+      <span
+        v-if="backup.isCurrent"
+        data-testid="active-status"
+        class="text-app-warning text-xs font-bold px-2"
+      >
+        ACTIVE
+      </span>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/CurrentStatusCard.vue
+++ b/frontend/src/components/CurrentStatusCard.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+/**
+ * CurrentStatusCard 組件
+ * @description 顯示當前環境狀態、訂閱資訊和操作按鈕
+ * @requirements 8.1-8.4
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from './Icon.vue'
+import NumberFlow from './NumberFlow.vue'
+import { getSubscriptionColorClass, getSubscriptionShortName } from '../utils/subscription'
+import type { CurrentUsageInfo, BackupItem } from '../types/backup'
+
+// ============================================================================
+// Props 定義
+// ============================================================================
+
+interface Props {
+  /** 當前環境名稱 */
+  currentEnvironmentName: string
+  /** 當前機器碼 */
+  currentMachineId: string
+  /** 當前 Provider */
+  currentProvider: string
+  /** 用量資訊 */
+  usageInfo: CurrentUsageInfo | null
+  /** 當前活躍的備份 */
+  activeBackup: BackupItem | null
+  /** 是否正在刷新 */
+  isRefreshing: boolean
+  /** 是否正在還原 */
+  isRestoring: boolean
+  /** 冷卻倒計時秒數 */
+  cooldownSeconds: number
+}
+
+const props = defineProps<Props>()
+
+// ============================================================================
+// Events 定義
+// ============================================================================
+
+const emit = defineEmits<{
+  (e: 'refresh'): void
+  (e: 'create-backup'): void
+  (e: 'restore-original'): void
+  (e: 'open-sso-cache'): void
+}>()
+
+// ============================================================================
+// i18n
+// ============================================================================
+
+const { t } = useI18n()
+
+// ============================================================================
+// 計算屬性
+// ============================================================================
+
+/** 是否在冷卻期 */
+const isInCooldown = computed(() => props.cooldownSeconds > 0)
+
+/** 顯示的環境名稱 */
+const displayEnvironmentName = computed(() => 
+  props.currentEnvironmentName || t('status.originalMachine')
+)
+
+/** 顯示的機器碼 */
+const displayMachineId = computed(() => props.currentMachineId || '-')
+
+/** 訂閱類型顏色類別 */
+const subscriptionClass = computed(() => 
+  props.usageInfo ? getSubscriptionColorClass(props.usageInfo.subscriptionTitle) : ''
+)
+
+/** 訂閱類型簡稱 */
+const subscriptionShortName = computed(() => 
+  props.usageInfo ? getSubscriptionShortName(props.usageInfo.subscriptionTitle) : ''
+)
+
+/** 當前 Provider（優先使用 activeBackup 的 provider） */
+const currentDisplayProvider = computed(() => 
+  props.activeBackup?.provider || props.currentProvider
+)
+
+// ============================================================================
+// 事件處理
+// ============================================================================
+
+const handleRefresh = () => {
+  if (!isInCooldown.value && !props.isRefreshing) {
+    emit('refresh')
+  }
+}
+
+const handleCreateBackup = () => {
+  emit('create-backup')
+}
+
+const handleRestoreOriginal = () => {
+  if (!props.isRestoring) {
+    emit('restore-original')
+  }
+}
+
+const handleOpenSSOCache = () => {
+  emit('open-sso-cache')
+}
+</script>
+
+<template>
+  <div class="lg:col-span-3 bg-gradient-to-br from-zinc-900 to-zinc-900/50 border border-app-border rounded-xl p-6 relative overflow-hidden group">
+    <!-- 背景圖標：根據 Provider 動態顯示，點擊打開 SSO Cache 文件夾 -->
+    <div 
+      data-testid="provider-icon"
+      @click="handleOpenSSOCache"
+      class="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 hover:!opacity-40 transition-opacity cursor-pointer z-20"
+      :title="t('status.openSSOCache')"
+    >
+      <Icon v-if="currentDisplayProvider === 'Github'" name="Github" class="w-32 h-32 text-white pointer-events-none" />
+      <Icon v-else-if="currentDisplayProvider === 'AWS' || currentDisplayProvider === 'BuilderId'" name="AWS" class="w-32 h-32 text-white pointer-events-none" />
+      <Icon v-else-if="currentDisplayProvider === 'Enterprise'" name="AWS" class="w-32 h-32 text-white pointer-events-none" />
+      <Icon v-else-if="currentDisplayProvider === 'Google'" name="Google" class="w-32 h-32 text-white pointer-events-none" />
+      <Icon v-else name="Cpu" class="w-32 h-32 text-white pointer-events-none" />
+    </div>
+    
+    <div class="relative z-10">
+      <!-- 標籤列：當前狀態 + 訂閱類型 + 餘額 + 刷新按鈕 -->
+      <div class="flex items-center gap-2 mb-4">
+        <span class="px-2 py-0.5 rounded text-[10px] font-bold bg-app-warning text-black uppercase tracking-wider">
+          {{ t('status.current') }}
+        </span>
+        
+        <!-- 顯示當前帳號訂閱和餘額 -->
+        <template v-if="usageInfo">
+          <!-- 訂閱類型標籤 -->
+          <span 
+            data-testid="subscription-badge"
+            :class="['px-2 py-0.5 rounded text-[10px] font-medium', subscriptionClass]"
+          >
+            {{ subscriptionShortName }}
+          </span>
+          
+          <!-- 餘額資訊 -->
+          <span 
+            data-testid="balance-info"
+            :class="[
+              'text-xs font-mono',
+              usageInfo.isLowBalance ? 'text-app-warning' : 'text-zinc-400'
+            ]"
+          >
+            <span v-if="usageInfo.isLowBalance" class="inline-flex items-center gap-1">
+              <Icon name="AlertTriangle" class="w-3 h-3" />
+              <NumberFlow :value="Math.round(usageInfo.balance)" /> / <NumberFlow :value="Math.round(usageInfo.usageLimit)" />
+            </span>
+            <span v-else>
+              <NumberFlow :value="Math.round(usageInfo.balance)" /> / <NumberFlow :value="Math.round(usageInfo.usageLimit)" />
+            </span>
+          </span>
+          
+          <!-- 刷新按鈕 / 倒計時 -->
+          <button
+            data-testid="refresh-btn"
+            @click="handleRefresh"
+            :disabled="isRefreshing || isInCooldown"
+            :class="[
+              'w-[22px] h-[22px] rounded transition-all inline-flex items-center justify-center',
+              isRefreshing
+                ? 'text-app-accent cursor-wait'
+                : isInCooldown
+                  ? 'text-zinc-500 cursor-not-allowed'
+                  : 'text-zinc-500 hover:text-zinc-300'
+            ]"
+            :title="t('backup.refresh')"
+          >
+            <!-- 刷新中：旋轉圖標 -->
+            <Icon 
+              v-if="isRefreshing"
+              name="RefreshCw" 
+              class="w-3.5 h-3.5 animate-spin" 
+            />
+            <!-- 倒計時數字 -->
+            <span 
+              v-else-if="isInCooldown" 
+              class="text-xs font-mono font-medium leading-none"
+            >
+              <NumberFlow :value="cooldownSeconds" />
+            </span>
+            <!-- 正常狀態：靜態圖標 -->
+            <Icon 
+              v-else
+              name="RefreshCw" 
+              class="w-3.5 h-3.5" 
+            />
+          </button>
+        </template>
+      </div>
+      
+      <!-- 環境名稱 -->
+      <h3 class="text-3xl font-bold text-white mb-1 glow-text">
+        {{ displayEnvironmentName }}
+      </h3>
+      
+      <!-- 機器碼 -->
+      <div class="flex items-center gap-2 text-app-accent font-mono text-sm mb-6">
+        <Icon name="Check" class="w-4 h-4" />
+        {{ displayMachineId }}
+      </div>
+
+      <!-- 操作按鈕 -->
+      <div class="flex gap-3">
+        <!-- 建立備份按鈕 -->
+        <button 
+          data-testid="create-backup-btn"
+          @click="handleCreateBackup"
+          class="flex items-center px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-600 text-zinc-200 rounded-lg text-sm transition-all active:scale-95"
+        >
+          <Icon name="Save" class="w-4 h-4 mr-2" />
+          {{ t('backup.create') }}
+        </button>
+        
+        <!-- 還原原始機器按鈕 -->
+        <button 
+          data-testid="restore-original-btn"
+          @click="handleRestoreOriginal"
+          :disabled="isRestoring"
+          :class="[
+            'flex items-center px-4 py-2 border rounded-lg text-sm transition-all',
+            isRestoring
+              ? 'bg-zinc-800/50 border-zinc-700/50 text-zinc-500 cursor-wait'
+              : 'bg-zinc-800/50 hover:bg-red-900/30 border-zinc-700/50 hover:border-red-800/50 text-zinc-400 hover:text-red-400'
+          ]"
+        >
+          <Icon 
+            name="Rotate" 
+            :class="['w-4 h-4 mr-2', isRestoring ? 'animate-spin' : '']" 
+          />
+          {{ isRestoring ? t('app.processing') : t('restore.original') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/FolderTree.vue
+++ b/frontend/src/components/FolderTree.vue
@@ -1,0 +1,388 @@
+<script setup lang="ts">
+/**
+ * FolderTree 組件
+ * @description 顯示文件夾樹狀結構，包含文件夾列表和未分類區域
+ * @requirements Task 6.1-6.7
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from './Icon.vue'
+import BackupCard from './BackupCard.vue'
+import type { FolderItem, BackupItem } from '@/types/backup'
+
+// ============================================================================
+// Props 定義 (Task 6.1)
+// ============================================================================
+
+interface Props {
+  folders: FolderItem[]
+  backups: BackupItem[]
+  expandedFolders: Set<string>
+  uncategorizedExpanded: boolean
+  dragOverFolderId: string | null
+  dragOverUncategorized: boolean
+  renamingFolder: string | null
+  renameFolderName: string
+  deletingFolder: string | null
+  selectedBackups: Set<string>
+  switchingBackup: string | null
+  deletingBackup: string | null
+  refreshingBackup: string | null
+  regeneratingId: string | null
+  countdownTimers: Record<string, number>
+  copiedMachineId: string | null
+}
+
+const props = defineProps<Props>()
+
+// ============================================================================
+// Events 定義 (Task 6.1)
+// ============================================================================
+
+const emit = defineEmits<{
+  // 文件夾事件
+  (e: 'toggle-folder', folderId: string): void
+  (e: 'toggle-uncategorized'): void
+  (e: 'start-rename-folder', folder: FolderItem): void
+  (e: 'confirm-rename-folder'): void
+  (e: 'cancel-rename-folder'): void
+  (e: 'delete-folder', folder: FolderItem): void
+  (e: 'create-folder'): void
+  // 拖放事件
+  (e: 'drag-enter-folder', folderId: string): void
+  (e: 'drag-leave-folder'): void
+  (e: 'drag-enter-uncategorized'): void
+  (e: 'drag-leave-uncategorized'): void
+  (e: 'drop-to-folder', event: DragEvent, folderId: string): void
+  (e: 'drop-to-uncategorized', event: DragEvent): void
+  // 備份操作事件
+  (e: 'toggle-select', name: string): void
+  (e: 'toggle-select-all'): void
+  (e: 'switch-backup', name: string): void
+  (e: 'delete-backup', name: string): void
+  (e: 'refresh-backup', name: string): void
+  (e: 'regenerate-id', name: string): void
+  (e: 'copy-machine-id', machineId: string): void
+  (e: 'drag-start', event: DragEvent, name: string): void
+  (e: 'drag-end', event: DragEvent): void
+}>()
+
+// ============================================================================
+// i18n
+// ============================================================================
+
+const { t } = useI18n()
+
+// ============================================================================
+// 計算屬性 (Task 6.2)
+// ============================================================================
+
+/**
+ * 取得指定文件夾內的備份列表
+ */
+const getBackupsInFolder = (folderId: string): BackupItem[] => {
+  return props.backups.filter(backup => backup.folderId === folderId)
+}
+
+/**
+ * 未分類的備份列表
+ */
+const uncategorizedBackups = computed(() => {
+  return props.backups.filter(backup => !backup.folderId)
+})
+
+/**
+ * 是否全選未分類備份
+ */
+const isAllSelected = computed(() => {
+  const uncategorized = uncategorizedBackups.value
+  if (uncategorized.length === 0) return false
+  return uncategorized.every(backup => props.selectedBackups.has(backup.name))
+})
+
+// ============================================================================
+// 事件處理
+// ============================================================================
+
+const onDragOver = (event: DragEvent) => {
+  event.preventDefault()
+}
+
+const handleToggleFolder = (folderId: string) => {
+  emit('toggle-folder', folderId)
+}
+
+const handleToggleUncategorized = () => {
+  emit('toggle-uncategorized')
+}
+
+const handleStartRename = (folder: FolderItem) => {
+  emit('start-rename-folder', folder)
+}
+
+const handleConfirmRename = () => {
+  emit('confirm-rename-folder')
+}
+
+const handleCancelRename = () => {
+  emit('cancel-rename-folder')
+}
+
+const handleDeleteFolder = (folder: FolderItem) => {
+  emit('delete-folder', folder)
+}
+
+const handleDragEnterFolder = (folderId: string) => {
+  emit('drag-enter-folder', folderId)
+}
+
+const handleDragLeaveFolder = () => {
+  emit('drag-leave-folder')
+}
+
+const handleDropToFolder = (event: DragEvent, folderId: string) => {
+  emit('drop-to-folder', event, folderId)
+}
+
+const handleDragEnterUncategorized = () => {
+  emit('drag-enter-uncategorized')
+}
+
+const handleDragLeaveUncategorized = () => {
+  emit('drag-leave-uncategorized')
+}
+
+const handleDropToUncategorized = (event: DragEvent) => {
+  emit('drop-to-uncategorized', event)
+}
+
+const handleToggleSelectAll = () => {
+  emit('toggle-select-all')
+}
+
+// BackupCard 事件轉發
+const handleSelect = (name: string) => {
+  emit('toggle-select', name)
+}
+
+const handleSwitch = (name: string) => {
+  emit('switch-backup', name)
+}
+
+const handleDelete = (name: string) => {
+  emit('delete-backup', name)
+}
+
+const handleRefresh = (name: string) => {
+  emit('refresh-backup', name)
+}
+
+const handleRegenerateId = (name: string) => {
+  emit('regenerate-id', name)
+}
+
+const handleCopyMachineId = (machineId: string) => {
+  emit('copy-machine-id', machineId)
+}
+
+const handleDragStart = (event: DragEvent, name: string) => {
+  emit('drag-start', event, name)
+}
+
+const handleDragEnd = (event: DragEvent) => {
+  emit('drag-end', event)
+}
+
+/**
+ * 檢查備份是否在冷卻中
+ */
+const isInCooldown = (name: string): boolean => {
+  return (props.countdownTimers[name] || 0) > 0
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- 文件夾列表 (Task 6.3-6.5) -->
+    <div class="space-y-3">
+      <div 
+        v-for="folder in folders" 
+        :key="folder.id"
+        :data-testid="`folder-${folder.id}`"
+        class="bg-app-surface border border-app-border rounded-xl overflow-hidden"
+        :class="{ 'ring-2 ring-app-accent': dragOverFolderId === folder.id }"
+        @dragover="onDragOver"
+        @dragenter="handleDragEnterFolder(folder.id)"
+        @dragleave="handleDragLeaveFolder"
+        @drop="handleDropToFolder($event, folder.id)"
+      >
+        <!-- 文件夾標題 -->
+        <div 
+          :data-testid="`folder-header-${folder.id}`"
+          class="flex items-center justify-between px-4 py-3 bg-zinc-900/50 cursor-pointer hover:bg-zinc-800/50 transition-colors"
+          @click="handleToggleFolder(folder.id)"
+        >
+          <div class="flex items-center gap-3">
+            <Icon 
+              :name="expandedFolders.has(folder.id) ? 'ChevronDown' : 'ChevronRight'" 
+              class="w-4 h-4 text-zinc-500 transition-transform" 
+            />
+            <Icon name="Folder" class="w-4 h-4 text-app-accent" />
+            
+            <!-- 重新命名模式 -->
+            <template v-if="renamingFolder === folder.id">
+              <input 
+                v-model="props.renameFolderName"
+                :data-testid="`rename-input-${folder.id}`"
+                @click.stop
+                @keyup.enter="handleConfirmRename"
+                @keyup.escape="handleCancelRename"
+                class="px-2 py-1 bg-zinc-800 border border-zinc-600 rounded text-sm text-zinc-200 focus:outline-none focus:border-app-accent"
+                autofocus
+              />
+              <button 
+                :data-testid="`confirm-rename-btn-${folder.id}`"
+                @click.stop="handleConfirmRename" 
+                class="p-1 text-app-success hover:bg-zinc-700 rounded"
+              >
+                <Icon name="Check" class="w-4 h-4" />
+              </button>
+              <button 
+                :data-testid="`cancel-rename-btn-${folder.id}`"
+                @click.stop="handleCancelRename" 
+                class="p-1 text-zinc-400 hover:bg-zinc-700 rounded"
+              >
+                <Icon name="X" class="w-4 h-4" />
+              </button>
+            </template>
+            <template v-else>
+              <span class="text-zinc-200 font-medium">{{ folder.name }}</span>
+              <span class="text-zinc-500 text-xs">({{ folder.snapshotCount }})</span>
+            </template>
+          </div>
+          
+          <!-- 文件夾操作按鈕 -->
+          <div class="flex items-center gap-1" @click.stop>
+            <button 
+              :data-testid="`rename-btn-${folder.id}`"
+              @click="handleStartRename(folder)"
+              class="p-1.5 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700/50 rounded transition-colors"
+              :title="t('folder.rename')"
+            >
+              <Icon name="Edit" class="w-3.5 h-3.5" />
+            </button>
+            <button 
+              :data-testid="`delete-btn-${folder.id}`"
+              @click="handleDeleteFolder(folder)"
+              :disabled="deletingFolder === folder.id"
+              class="p-1.5 text-zinc-500 hover:text-red-400 hover:bg-zinc-700/50 rounded transition-colors"
+              :title="t('folder.delete')"
+            >
+              <Icon name="Trash" class="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+        
+        <!-- 文件夾內容（展開時顯示）(Task 6.4) -->
+        <div 
+          v-if="expandedFolders.has(folder.id)" 
+          :data-testid="`folder-content-${folder.id}`"
+          class="border-t border-zinc-800"
+        >
+          <div v-if="getBackupsInFolder(folder.id).length === 0" class="px-4 py-6 text-center text-zinc-500 text-sm">
+            {{ t('folder.emptyFolder') }}
+          </div>
+          <div v-else class="divide-y divide-zinc-800/50">
+            <BackupCard
+              v-for="backup in getBackupsInFolder(folder.id)"
+              :key="backup.name"
+              :backup="backup"
+              :is-selected="selectedBackups.has(backup.name)"
+              :is-switching="switchingBackup === backup.name"
+              :is-deleting="deletingBackup === backup.name"
+              :is-refreshing="refreshingBackup === backup.name"
+              :is-regenerating="regeneratingId === backup.name"
+              :cooldown-seconds="countdownTimers[backup.name] || 0"
+              :copied-machine-id="copiedMachineId"
+              @select="handleSelect"
+              @switch="handleSwitch"
+              @delete="handleDelete"
+              @refresh="handleRefresh"
+              @regenerate-id="handleRegenerateId"
+              @copy-machine-id="handleCopyMachineId"
+              @drag-start="handleDragStart"
+              @drag-end="handleDragEnd"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 未分類區域 (Task 6.6-6.7) -->
+    <div 
+      data-testid="uncategorized-section"
+      class="bg-app-surface border border-app-border rounded-xl overflow-hidden"
+      :class="{ 'ring-2 ring-app-accent': dragOverUncategorized }"
+      @dragover="onDragOver"
+      @dragenter="handleDragEnterUncategorized"
+      @dragleave="handleDragLeaveUncategorized"
+      @drop="handleDropToUncategorized"
+    >
+      <!-- 未分類標題 -->
+      <div 
+        data-testid="uncategorized-header"
+        class="flex items-center justify-between px-4 py-3 bg-zinc-900/50 cursor-pointer hover:bg-zinc-800/50 transition-colors"
+        @click="handleToggleUncategorized"
+      >
+        <div class="flex items-center gap-3">
+          <Icon 
+            :name="uncategorizedExpanded ? 'ChevronDown' : 'ChevronRight'" 
+            class="w-4 h-4 text-zinc-500 transition-transform" 
+          />
+          <Icon name="Inbox" class="w-4 h-4 text-zinc-500" />
+          <span class="text-zinc-400 font-medium">{{ t('folder.uncategorized') }}</span>
+          <span class="text-zinc-500 text-xs">({{ uncategorizedBackups.length }})</span>
+        </div>
+        <!-- 全選 checkbox -->
+        <div @click.stop>
+          <input 
+            type="checkbox"
+            data-testid="select-all-checkbox"
+            :checked="isAllSelected"
+            @change="handleToggleSelectAll"
+            class="custom-checkbox"
+          />
+        </div>
+      </div>
+      
+      <!-- 未分類內容（展開時顯示） -->
+      <div v-if="uncategorizedExpanded" class="border-t border-zinc-800">
+        <div v-if="uncategorizedBackups.length === 0" class="px-4 py-6 text-center text-zinc-500 text-sm">
+          {{ t('backup.noBackups') }}
+        </div>
+        <div v-else class="divide-y divide-zinc-800/50">
+          <BackupCard
+            v-for="backup in uncategorizedBackups"
+            :key="backup.name"
+            :backup="backup"
+            :is-selected="selectedBackups.has(backup.name)"
+            :is-switching="switchingBackup === backup.name"
+            :is-deleting="deletingBackup === backup.name"
+            :is-refreshing="refreshingBackup === backup.name"
+            :is-regenerating="regeneratingId === backup.name"
+            :cooldown-seconds="countdownTimers[backup.name] || 0"
+            :copied-machine-id="copiedMachineId"
+            @select="handleSelect"
+            @switch="handleSwitch"
+            @delete="handleDelete"
+            @refresh="handleRefresh"
+            @regenerate-id="handleRegenerateId"
+            @copy-machine-id="handleCopyMachineId"
+            @drag-start="handleDragStart"
+            @drag-end="handleDragEnd"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/NumberFlow.vue
+++ b/frontend/src/components/NumberFlow.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+/**
+ * NumberFlow 數字動畫組件
+ * @description 封裝 @number-flow/vue，提供統一的數字動畫效果
+ * @see https://number-flow.barvian.me/vue
+ */
+import NumberFlow, { type Format } from '@number-flow/vue'
+
+interface Props {
+  /** 要顯示的數值 */
+  value: number
+  /** 數字格式化選項 */
+  format?: Format
+  /** 前綴文字 */
+  prefix?: string
+  /** 後綴文字 */
+  suffix?: string
+  /** 是否啟用動畫 */
+  animated?: boolean
+}
+
+withDefaults(defineProps<Props>(), {
+  animated: true,
+})
+</script>
+
+<template>
+  <NumberFlow
+    :value="value"
+    :format="format"
+    :prefix="prefix"
+    :suffix="suffix"
+    :animated="animated"
+  />
+</template>

--- a/frontend/src/components/NumberInput.vue
+++ b/frontend/src/components/NumberInput.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+/**
+ * NumberInput 數字輸入組件
+ * @description 帶有加減按鈕的數字輸入框，使用 NumberFlow 動畫效果
+ */
+import { computed, onMounted, ref } from 'vue'
+import NumberFlow, { useCanAnimate } from '@number-flow/vue'
+
+// 檢測動畫支援
+const canAnimate = useCanAnimate()
+
+// 調試信息（開發時可見）
+const debugInfo = ref<{
+  canAnimate: boolean
+  supportsMod: boolean
+  supportsLinear: boolean
+  supportsAtProperty: boolean
+  chromiumVersion: string
+} | null>(null)
+
+// 調試：在控制台輸出動畫支援狀態
+onMounted(() => {
+  // 檢測各項功能支援
+  const supportsMod = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('line-height', 'mod(1,1)')
+  const supportsLinear = (() => {
+    try {
+      document.createElement('div').animate({ opacity: 0 }, { easing: 'linear(0, 1)' })
+      return true
+    } catch (e) {
+      return false
+    }
+  })()
+  const supportsAtProperty = (() => {
+    try {
+      CSS.registerProperty({
+        name: '--test-number-input-prop',
+        syntax: '<number>',
+        inherits: false,
+        initialValue: '0'
+      })
+      return true
+    } catch {
+      return false
+    }
+  })()
+  
+  // 提取 Chromium 版本
+  const ua = navigator.userAgent
+  const chromiumMatch = ua.match(/Chrome\/(\d+)/)
+  const chromiumVersion = chromiumMatch ? chromiumMatch[1] : 'unknown'
+  
+  debugInfo.value = {
+    canAnimate: canAnimate.value,
+    supportsMod,
+    supportsLinear,
+    supportsAtProperty,
+    chromiumVersion
+  }
+  
+  console.log('[NumberInput] Feature detection:', debugInfo.value)
+  console.log('[NumberInput] UserAgent:', ua)
+  
+  // 如果不支援動畫，輸出警告
+  if (!canAnimate.value) {
+    console.warn('[NumberInput] Animation not supported! Required: CSS mod() (Chrome 125+), linear() easing, CSS.registerProperty')
+    if (!supportsMod) {
+      console.warn('[NumberInput] CSS mod() not supported. Current Chrome version:', chromiumVersion, '(requires 125+)')
+    }
+  }
+})
+
+interface Props {
+  /** 當前數值 */
+  modelValue: number
+  /** 最小值 */
+  min?: number
+  /** 最大值 */
+  max?: number
+  /** 步進值 */
+  step?: number
+  /** 是否禁用 */
+  disabled?: boolean
+  /** 數字顯示區域最小寬度 (Tailwind class，如 'min-w-[3rem]') */
+  minWidth?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  min: 0,
+  max: Infinity,
+  step: 1,
+  disabled: false,
+  minWidth: 'min-w-[3rem]',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number]
+}>()
+
+const canDecrease = computed(() => !props.disabled && props.modelValue > props.min)
+const canIncrease = computed(() => !props.disabled && props.modelValue < props.max)
+
+function decrease() {
+  if (canDecrease.value) {
+    const newValue = Math.max(props.min, props.modelValue - props.step)
+    emit('update:modelValue', newValue)
+  }
+}
+
+function increase() {
+  if (canIncrease.value) {
+    const newValue = Math.min(props.max, props.modelValue + props.step)
+    emit('update:modelValue', newValue)
+  }
+}
+</script>
+
+<template>
+  <div 
+    :class="[
+      'inline-flex items-center rounded border transition-colors',
+      disabled 
+        ? 'border-zinc-700 bg-zinc-900/50 opacity-50' 
+        : 'border-violet-500/50 bg-zinc-900 hover:border-violet-500'
+    ]"
+  >
+    <!-- 減號按鈕 -->
+    <button
+      type="button"
+      :disabled="!canDecrease"
+      :class="[
+        'px-2 py-1 text-sm font-bold transition-colors',
+        canDecrease 
+          ? 'text-zinc-300 hover:text-white' 
+          : 'text-zinc-600 cursor-not-allowed'
+      ]"
+      @click="decrease"
+    >
+      −
+    </button>
+    
+    <!-- 數字顯示區域 -->
+    <div :class="['px-1.5 py-1 text-center', minWidth]">
+      <NumberFlow 
+        :value="modelValue" 
+        class="text-sm font-semibold text-white tabular-nums"
+      />
+    </div>
+    
+    <!-- 加號按鈕 -->
+    <button
+      type="button"
+      :disabled="!canIncrease"
+      :class="[
+        'px-2 py-1 text-sm font-bold transition-colors',
+        canIncrease 
+          ? 'text-zinc-300 hover:text-white' 
+          : 'text-zinc-600 cursor-not-allowed'
+      ]"
+      @click="increase"
+    >
+      +
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/SoftResetCard.vue
+++ b/frontend/src/components/SoftResetCard.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from './Icon.vue'
+import type { SoftResetStatus } from '@/types/backup'
+
+// ============================================================================
+// Props & Emits
+// ============================================================================
+
+interface Props {
+  softResetStatus: SoftResetStatus
+  isResetting: boolean
+  isPatching: boolean
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  (e: 'reset'): void
+  (e: 'patch'): void
+  (e: 'restore'): void
+  (e: 'open-extension-folder'): void
+  (e: 'open-machine-id-folder'): void
+}>()
+
+// ============================================================================
+// i18n
+// ============================================================================
+
+const { t } = useI18n()
+
+// ============================================================================
+// Computed
+// ============================================================================
+
+/** 是否完全啟用（已 Patch 且有自訂 ID） */
+const isFullyActive = computed(() => 
+  props.softResetStatus.isPatched && props.softResetStatus.hasCustomId
+)
+</script>
+
+<template>
+  <div class="lg:col-span-2 bg-zinc-900 border border-app-border rounded-xl p-4 flex flex-col">
+    <!-- 上方：PATCH 狀態 -->
+    <div class="flex items-center gap-2 mb-3">
+      <Icon name="Cpu" class="w-4 h-4 text-zinc-400" />
+      <span class="text-zinc-400 text-xs font-semibold uppercase tracking-wider">{{ t('status.patchStatus') }}</span>
+    </div>
+    
+    <div class="space-y-2 mb-4">
+      <!-- Extension Patch 狀態 -->
+      <div class="flex items-center justify-between">
+        <span class="text-zinc-500 text-sm">Extension Patch</span>
+        <div class="flex items-center gap-2">
+          <!-- 已 Patch：顯示靜態標籤 -->
+          <span 
+            v-if="softResetStatus.isPatched"
+            data-testid="patched-label"
+            class="px-2 py-0.5 rounded text-xs font-medium bg-app-success/20 text-app-success border border-app-success/30"
+          >
+            {{ t('status.patched') }}
+          </span>
+          <!-- 未 Patch：顯示可點擊按鍵 -->
+          <button
+            v-else
+            data-testid="patch-btn"
+            @click="emit('patch')"
+            :disabled="isPatching"
+            :class="[
+              'px-2 py-0.5 rounded text-xs font-medium transition-all',
+              isPatching
+                ? 'bg-zinc-700/50 text-zinc-500 border border-zinc-600/30 cursor-wait'
+                : 'bg-app-warning/20 text-app-warning border border-app-warning/30 hover:bg-app-warning/30 cursor-pointer'
+            ]"
+            :title="t('status.clickToPatch')"
+          >
+            <span v-if="isPatching" class="flex items-center gap-1">
+              <Icon name="Loader" class="w-3 h-3 animate-spin" />
+              {{ t('status.patching') }}
+            </span>
+            <span v-else>{{ t('status.notPatched') }}</span>
+          </button>
+          <button
+            v-if="softResetStatus.extensionPath"
+            data-testid="open-extension-folder-btn"
+            @click="emit('open-extension-folder')"
+            class="p-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700/50 transition-colors"
+            :title="t('status.openFolder')"
+          >
+            <Icon name="FolderOpen" class="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+      
+      <!-- Machine ID 狀態 -->
+      <div class="flex items-center justify-between">
+        <span class="text-zinc-500 text-sm">Machine ID</span>
+        <div class="flex items-center gap-2">
+          <span 
+            data-testid="machine-id-status"
+            :class="[
+              'px-2 py-0.5 rounded text-xs font-medium',
+              softResetStatus.hasCustomId 
+                ? 'bg-app-accent/20 text-app-accent border border-app-accent/30' 
+                : 'bg-zinc-700/50 text-zinc-400 border border-zinc-600/30'
+            ]"
+          >
+            {{ softResetStatus.hasCustomId ? t('status.hasCustomId') : t('status.noCustomId') }}
+          </span>
+          <button
+            data-testid="open-machine-id-folder-btn"
+            @click="emit('open-machine-id-folder')"
+            class="p-1 rounded text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700/50 transition-colors"
+            :title="t('status.openFolder')"
+          >
+            <Icon name="FolderOpen" class="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+      
+      <!-- 總體狀態指示 -->
+      <div class="flex items-center gap-2 pt-1">
+        <div 
+          data-testid="status-indicator"
+          :class="[
+            'w-2 h-2 rounded-full',
+            isFullyActive 
+              ? 'bg-app-success shadow-[0_0_6px_rgba(34,197,94,0.6)]' 
+              : 'bg-zinc-500'
+          ]"
+        ></div>
+        <span :class="[
+          'text-xs font-medium',
+          isFullyActive 
+            ? 'text-app-success' 
+            : 'text-zinc-500'
+        ]">
+          {{ isFullyActive ? t('status.softResetActive') : t('status.softResetInactive') }}
+        </span>
+      </div>
+    </div>
+    
+    <!-- 下方：按鈕區域 -->
+    <div class="mt-auto space-y-2">
+      <!-- 一鍵新機按鈕 -->
+      <button 
+        data-testid="reset-btn"
+        @click="emit('reset')"
+        :disabled="isResetting"
+        :class="[
+          'w-full relative group flex items-center justify-center gap-3 px-4 py-3 border rounded-lg transition-all',
+          isResetting 
+            ? 'bg-app-accent border-app-accent cursor-wait' 
+            : 'bg-zinc-800 hover:bg-app-accent border-zinc-700 hover:border-app-accent active:scale-95'
+        ]"
+      >
+        <!-- 一鍵新機 SVG Icon -->
+        <svg width="32" height="32" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" class="flex-shrink-0">
+          <!-- 手機主體 (靜態) -->
+          <rect x="25" y="15" width="50" height="80" rx="6" stroke="currentColor" stroke-width="4" fill="none"/>
+          <line x1="42" y1="22" x2="58" y2="22" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="50" cy="85" r="3" fill="currentColor"/>
+          
+          <!-- 進行中：只顯示持續旋轉的箭頭 -->
+          <g v-if="isResetting">
+            <path d="M50 40 A 15 15 0 1 1 38 63" stroke="currentColor" stroke-width="3" stroke-linecap="round" fill="none" />
+            <path d="M38 63 L34 58 M38 63 L43 59" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            <animateTransform attributeName="transform" type="rotate" from="0 50 55" to="360 50 55" dur="0.6s" repeatCount="indefinite" />
+          </g>
+          
+          <!-- 靜態：不旋轉的箭頭 -->
+          <g v-else>
+            <path d="M50 40 A 15 15 0 1 1 38 63" stroke="currentColor" stroke-width="3" stroke-linecap="round" fill="none" />
+            <path d="M38 63 L34 58 M38 63 L43 59" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          </g>
+        </svg>
+        <div class="text-left">
+          <span :class="['text-sm font-bold block', isResetting ? 'text-white' : 'text-zinc-200 group-hover:text-white']">
+            {{ isResetting ? t('app.processing') : t('restore.reset') }}
+          </span>
+          <span :class="['text-[10px]', isResetting ? 'text-zinc-200' : 'text-zinc-500 group-hover:text-zinc-300']">
+            {{ isResetting ? t('message.successChange') : t('restore.resetDesc') }}
+          </span>
+        </div>
+      </button>
+      
+      <!-- 還原原始機器按鈕 -->
+      <button
+        data-testid="restore-btn"
+        @click="emit('restore')"
+        :disabled="!softResetStatus.hasCustomId"
+        :class="[
+          'w-full px-3 py-2 rounded-lg text-sm font-medium transition-all',
+          softResetStatus.hasCustomId
+            ? 'bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white border border-zinc-700'
+            : 'bg-zinc-800/50 text-zinc-600 border border-zinc-700/50 cursor-not-allowed'
+        ]"
+      >
+        {{ t('restore.original') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/__tests__/BackupCard.property.spec.ts
+++ b/frontend/src/components/__tests__/BackupCard.property.spec.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import * as fc from 'fast-check'
+import BackupCard from '../BackupCard.vue'
+
+// Mock Icon component
+const IconStub = {
+  name: 'Icon',
+  template: '<span class="icon-stub" :data-name="name"></span>',
+  props: ['name'],
+}
+
+// Arbitrary for backup data
+const backupArbitrary = fc.record({
+  name: fc.string({ minLength: 1, maxLength: 50 }),
+  provider: fc.constantFrom('Github', 'AWS', 'BuilderId', 'Enterprise', 'Google') as fc.Arbitrary<'Github' | 'AWS' | 'BuilderId' | 'Enterprise' | 'Google'>,
+  subscriptionTitle: fc.constantFrom('KIRO FREE', 'KIRO PRO', 'KIRO PRO+', 'KIRO POWER', ''),
+  usageLimit: fc.integer({ min: 0, max: 10000 }),
+  currentUsage: fc.integer({ min: 0, max: 10000 }),
+  balance: fc.integer({ min: 0, max: 10000 }),
+  isLowBalance: fc.boolean(),
+  isCurrent: fc.boolean(),
+  isOriginalMachine: fc.boolean(),
+  machineId: fc.string({ minLength: 0, maxLength: 64 }),
+  isTokenExpired: fc.boolean(),
+})
+
+describe('Feature: ui-component-extraction, BackupCard Property Tests', () => {
+  // ============================================================================
+  // Property 4: 當前備份不顯示操作按鈕
+  // Validates: Requirements 8.3, 9.3, 11.3
+  // ============================================================================
+
+  describe('Property 4: 當前備份不顯示操作按鈕', () => {
+    it('should consistently hide action buttons when isCurrent is true', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isCurrent: true })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const switchBtn = wrapper.find('[data-testid="switch-btn"]')
+            const deleteBtn = wrapper.find('[data-testid="delete-btn"]')
+            const regenerateBtn = wrapper.find('[data-testid="regenerate-btn"]')
+            const activeStatus = wrapper.find('[data-testid="active-status"]')
+
+            return (
+              !switchBtn.exists() &&
+              !deleteBtn.exists() &&
+              !regenerateBtn.exists() &&
+              activeStatus.exists()
+            )
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('should consistently show action buttons when isCurrent is false', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isCurrent: false })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const switchBtn = wrapper.find('[data-testid="switch-btn"]')
+            const deleteBtn = wrapper.find('[data-testid="delete-btn"]')
+            const regenerateBtn = wrapper.find('[data-testid="regenerate-btn"]')
+            const activeStatus = wrapper.find('[data-testid="active-status"]')
+
+            return (
+              switchBtn.exists() &&
+              deleteBtn.exists() &&
+              regenerateBtn.exists() &&
+              !activeStatus.exists()
+            )
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Property 5: 冷卻期狀態正確顯示
+  // Validates: Requirements 10.3, 10.4
+  // ============================================================================
+
+  describe('Property 5: 冷卻期狀態正確顯示', () => {
+    it('should disable refresh button when cooldownSeconds > 0', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary,
+          fc.integer({ min: 1, max: 60 }),
+          (backup, cooldownSeconds) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+            const hasDisabled = refreshBtn.attributes('disabled') !== undefined
+            const showsCountdown = wrapper.text().includes(String(cooldownSeconds))
+
+            return hasDisabled && showsCountdown
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('should enable refresh button when cooldownSeconds is 0', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary,
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+            return refreshBtn.attributes('disabled') === undefined
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Property 7: 低餘額警告顯示一致性
+  // Validates: Requirements 6.5
+  // ============================================================================
+
+  describe('Property 7: 低餘額警告顯示一致性', () => {
+    it('should show warning style when isLowBalance is true and has usage data', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isLowBalance: true, usageLimit: 1000, balance: 100 })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const balanceEl = wrapper.find('[data-testid="balance"]')
+            return balanceEl.exists() && balanceEl.classes().includes('text-app-warning')
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('should show normal style when isLowBalance is false', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isLowBalance: false, usageLimit: 1000, balance: 500 })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const balanceEl = wrapper.find('[data-testid="balance"]')
+            return balanceEl.exists() && !balanceEl.classes().includes('text-app-warning')
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Property 11: Provider 圖標映射一致性
+  // Validates: Requirements 6.3
+  // ============================================================================
+
+  describe('Property 11: Provider 圖標映射一致性', () => {
+    it('should always render provider icon for any valid provider', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary,
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const providerIcon = wrapper.find('[data-testid="provider-icon"]')
+            return providerIcon.exists()
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Property 12: 選中狀態視覺反饋
+  // Validates: Requirements 7.2
+  // ============================================================================
+
+  describe('Property 12: 選中狀態視覺反饋', () => {
+    it('should reflect isSelected state in checkbox', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary,
+          fc.boolean(),
+          (backup, isSelected) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const checkbox = wrapper.find('input[type="checkbox"]')
+            const checkboxElement = checkbox.element as HTMLInputElement
+            return checkboxElement.checked === isSelected
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Property 6: 載入狀態正確顯示
+  // Validates: Requirements 8.2, 9.2, 10.2, 11.2
+  // ============================================================================
+
+  describe('Property 6: 載入狀態正確顯示', () => {
+    it('should show loading animation for switching state', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isCurrent: false })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: true,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const switchBtn = wrapper.find('[data-testid="switch-btn"]')
+            return switchBtn.exists() && switchBtn.classes().includes('animate-bounce')
+          }
+        ),
+        { numRuns: 30 }
+      )
+    })
+
+    it('should show loading animation for deleting state', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isCurrent: false })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: true,
+                isRefreshing: false,
+                isRegenerating: false,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const deleteBtn = wrapper.find('[data-testid="delete-btn"]')
+            return deleteBtn.exists() && deleteBtn.classes().includes('animate-pulse')
+          }
+        ),
+        { numRuns: 30 }
+      )
+    })
+
+    it('should show loading animation for regenerating state', () => {
+      fc.assert(
+        fc.property(
+          backupArbitrary.map(b => ({ ...b, isCurrent: false })),
+          (backup) => {
+            const wrapper = mount(BackupCard, {
+              props: {
+                backup,
+                isSelected: false,
+                isSwitching: false,
+                isDeleting: false,
+                isRefreshing: false,
+                isRegenerating: true,
+                cooldownSeconds: 0,
+                copiedMachineId: null,
+              },
+              global: {
+                stubs: { Icon: IconStub },
+              },
+            })
+
+            const regenerateBtn = wrapper.find('[data-testid="regenerate-btn"]')
+            return regenerateBtn.exists() && regenerateBtn.classes().includes('animate-pulse-fast')
+          }
+        ),
+        { numRuns: 30 }
+      )
+    })
+  })
+})

--- a/frontend/src/components/__tests__/BackupCard.spec.ts
+++ b/frontend/src/components/__tests__/BackupCard.spec.ts
@@ -1,0 +1,523 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import * as fc from 'fast-check'
+import BackupCard from '../BackupCard.vue'
+
+// Mock Icon component
+const IconStub = {
+  name: 'Icon',
+  template: '<span class="icon-stub" :data-name="name"></span>',
+  props: ['name'],
+}
+
+// 建立預設的 backup 物件
+const createDefaultBackup = (overrides = {}) => ({
+  name: 'test-backup',
+  provider: 'Github' as const,
+  subscriptionTitle: 'KIRO PRO',
+  usageLimit: 1000,
+  currentUsage: 500,
+  balance: 500,
+  isLowBalance: false,
+  isCurrent: false,
+  isOriginalMachine: false,
+  machineId: 'abc123def456',
+  isTokenExpired: false,
+  ...overrides,
+})
+
+// 建立預設的 props
+const createDefaultProps = (overrides = {}) => ({
+  backup: createDefaultBackup(),
+  isSelected: false,
+  isSwitching: false,
+  isDeleting: false,
+  isRefreshing: false,
+  isRegenerating: false,
+  cooldownSeconds: 0,
+  copiedMachineId: null,
+  ...overrides,
+})
+
+describe('Feature: ui-component-extraction, BackupCard Component', () => {
+  // ============================================================================
+  // Task 4.1: 組件骨架測試
+  // ============================================================================
+
+  describe('Task 4.1: 組件骨架', () => {
+    it('should render without errors', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should have draggable attribute', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.attributes('draggable')).toBe('true')
+    })
+  })
+
+  // ============================================================================
+  // Task 4.2: 渲染邏輯測試
+  // ============================================================================
+
+  describe('Task 4.2: 渲染邏輯', () => {
+    it('should render backup name', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ name: 'my-backup' }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.text()).toContain('my-backup')
+    })
+
+    it('should render original machine label when isOriginalMachine is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isOriginalMachine: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      // 應該有原始機器標籤
+      expect(wrapper.find('[data-testid="original-machine-label"]').exists()).toBe(true)
+    })
+
+    it('should render subscription type badge', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ subscriptionTitle: 'KIRO PRO+' }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.text()).toContain('PRO+')
+    })
+
+    it('should render balance information', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ balance: 750, usageLimit: 1000 }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.text()).toContain('750')
+      expect(wrapper.text()).toContain('1,000')
+    })
+
+    it('should render truncated machine ID', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ machineId: 'abcdefghijklmnop' }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      // 應該顯示截斷的 machine ID
+      expect(wrapper.text()).toContain('abcdefgh...')
+    })
+
+    it('should show active indicator when isCurrent is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isCurrent: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="active-indicator"]').exists()).toBe(true)
+    })
+  })
+
+  // ============================================================================
+  // Task 4.3: 操作按鈕測試
+  // ============================================================================
+
+  describe('Task 4.3: 操作按鈕', () => {
+    it('should emit select event when checkbox is clicked', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const checkbox = wrapper.find('input[type="checkbox"]')
+      await checkbox.trigger('change')
+      
+      expect(wrapper.emitted('select')).toBeTruthy()
+      expect(wrapper.emitted('select')![0]).toEqual(['test-backup'])
+    })
+
+    it('should emit switch event when switch button is clicked', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const switchBtn = wrapper.find('[data-testid="switch-btn"]')
+      await switchBtn.trigger('click')
+      
+      expect(wrapper.emitted('switch')).toBeTruthy()
+      expect(wrapper.emitted('switch')![0]).toEqual(['test-backup'])
+    })
+
+    it('should emit delete event when delete button is clicked', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const deleteBtn = wrapper.find('[data-testid="delete-btn"]')
+      await deleteBtn.trigger('click')
+      
+      expect(wrapper.emitted('delete')).toBeTruthy()
+      expect(wrapper.emitted('delete')![0]).toEqual(['test-backup'])
+    })
+
+    it('should emit refresh event when refresh button is clicked', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      await refreshBtn.trigger('click')
+      
+      expect(wrapper.emitted('refresh')).toBeTruthy()
+      expect(wrapper.emitted('refresh')![0]).toEqual(['test-backup'])
+    })
+
+    it('should emit regenerate-id event when regenerate button is clicked', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const regenerateBtn = wrapper.find('[data-testid="regenerate-btn"]')
+      await regenerateBtn.trigger('click')
+      
+      expect(wrapper.emitted('regenerate-id')).toBeTruthy()
+      expect(wrapper.emitted('regenerate-id')![0]).toEqual(['test-backup'])
+    })
+
+    it('should emit copy-machine-id event when machine ID is clicked', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ machineId: 'test-machine-id' }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const machineIdBtn = wrapper.find('[data-testid="machine-id-btn"]')
+      await machineIdBtn.trigger('click')
+      
+      expect(wrapper.emitted('copy-machine-id')).toBeTruthy()
+      expect(wrapper.emitted('copy-machine-id')![0]).toEqual(['test-machine-id'])
+    })
+  })
+
+  // ============================================================================
+  // Task 4.4: 拖放事件測試
+  // ============================================================================
+
+  describe('Task 4.4: 拖放事件', () => {
+    it('should emit drag-start event on dragstart', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      await wrapper.trigger('dragstart')
+      
+      expect(wrapper.emitted('drag-start')).toBeTruthy()
+    })
+
+    it('should emit drag-end event on dragend', async () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      await wrapper.trigger('dragend')
+      
+      expect(wrapper.emitted('drag-end')).toBeTruthy()
+    })
+  })
+
+  // ============================================================================
+  // Property 4: 當前備份不顯示操作按鈕
+  // Validates: Requirements 8.3, 9.3, 11.3
+  // ============================================================================
+
+  describe('Property 4: 當前備份不顯示操作按鈕', () => {
+    it('should hide switch, delete, regenerate buttons when isCurrent is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isCurrent: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      expect(wrapper.find('[data-testid="switch-btn"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="delete-btn"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="regenerate-btn"]').exists()).toBe(false)
+    })
+
+    it('should show switch, delete, regenerate buttons when isCurrent is false', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isCurrent: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      expect(wrapper.find('[data-testid="switch-btn"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="delete-btn"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="regenerate-btn"]').exists()).toBe(true)
+    })
+
+    it('should show active status label when isCurrent is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isCurrent: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      expect(wrapper.find('[data-testid="active-status"]').exists()).toBe(true)
+    })
+  })
+
+  // ============================================================================
+  // Property 5: 冷卻期狀態正確顯示
+  // Validates: Requirements 10.3, 10.4
+  // ============================================================================
+
+  describe('Property 5: 冷卻期狀態正確顯示', () => {
+    it('should show countdown when cooldownSeconds > 0', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          cooldownSeconds: 30,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      expect(wrapper.text()).toContain('30')
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      expect(refreshBtn.attributes('disabled')).toBeDefined()
+    })
+
+    it('should show refresh icon when cooldownSeconds is 0', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          cooldownSeconds: 0,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      expect(refreshBtn.attributes('disabled')).toBeUndefined()
+    })
+  })
+
+  // ============================================================================
+  // Property 6: 載入狀態正確顯示
+  // Validates: Requirements 8.2, 9.2, 10.2, 11.2
+  // ============================================================================
+
+  describe('Property 6: 載入狀態正確顯示', () => {
+    it('should show loading animation when isSwitching is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          isSwitching: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const switchBtn = wrapper.find('[data-testid="switch-btn"]')
+      expect(switchBtn.classes()).toContain('animate-bounce')
+    })
+
+    it('should show loading animation when isDeleting is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          isDeleting: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const deleteBtn = wrapper.find('[data-testid="delete-btn"]')
+      expect(deleteBtn.classes()).toContain('animate-pulse')
+    })
+
+    it('should show loading animation when isRefreshing is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          isRefreshing: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      expect(refreshBtn.find('.animate-spin').exists()).toBe(true)
+    })
+
+    it('should show loading animation when isRegenerating is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          isRegenerating: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const regenerateBtn = wrapper.find('[data-testid="regenerate-btn"]')
+      expect(regenerateBtn.classes()).toContain('animate-pulse-fast')
+    })
+  })
+
+  // ============================================================================
+  // Property 7: 低餘額警告顯示一致性
+  // Validates: Requirements 6.5
+  // ============================================================================
+
+  describe('Property 7: 低餘額警告顯示一致性', () => {
+    it('should show warning style when isLowBalance is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isLowBalance: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const balanceEl = wrapper.find('[data-testid="balance"]')
+      expect(balanceEl.classes()).toContain('text-app-warning')
+    })
+
+    it('should show normal style when isLowBalance is false', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          backup: createDefaultBackup({ isLowBalance: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const balanceEl = wrapper.find('[data-testid="balance"]')
+      expect(balanceEl.classes()).not.toContain('text-app-warning')
+    })
+  })
+
+  // ============================================================================
+  // Property 11: Provider 圖標映射一致性
+  // Validates: Requirements 6.3
+  // ============================================================================
+
+  describe('Property 11: Provider 圖標映射一致性', () => {
+    const providers = ['Github', 'AWS', 'BuilderId', 'Enterprise', 'Google'] as const
+
+    providers.forEach((provider) => {
+      it(`should render correct icon for ${provider} provider`, () => {
+        const wrapper = mount(BackupCard, {
+          props: createDefaultProps({
+            backup: createDefaultBackup({ provider }),
+          }),
+          global: {
+            stubs: { Icon: IconStub },
+          },
+        })
+        
+        const providerIcon = wrapper.find('[data-testid="provider-icon"]')
+        expect(providerIcon.exists()).toBe(true)
+      })
+    })
+  })
+
+  // ============================================================================
+  // Property 12: 選中狀態視覺反饋
+  // Validates: Requirements 7.2
+  // ============================================================================
+
+  describe('Property 12: 選中狀態視覺反饋', () => {
+    it('should show checked checkbox when isSelected is true', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          isSelected: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const checkbox = wrapper.find('input[type="checkbox"]')
+      expect((checkbox.element as HTMLInputElement).checked).toBe(true)
+    })
+
+    it('should show unchecked checkbox when isSelected is false', () => {
+      const wrapper = mount(BackupCard, {
+        props: createDefaultProps({
+          isSelected: false,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      
+      const checkbox = wrapper.find('input[type="checkbox"]')
+      expect((checkbox.element as HTMLInputElement).checked).toBe(false)
+    })
+  })
+})

--- a/frontend/src/components/__tests__/CurrentStatusCard.spec.ts
+++ b/frontend/src/components/__tests__/CurrentStatusCard.spec.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import CurrentStatusCard from '../CurrentStatusCard.vue'
+import type { CurrentUsageInfo, BackupItem } from '../../types/backup'
+
+// Mock Icon component
+const IconStub = {
+  name: 'Icon',
+  template: '<span class="icon-stub" :data-name="name"></span>',
+  props: ['name', 'class'],
+}
+
+// 建立 i18n 實例
+const i18n = createI18n({
+  legacy: false,
+  locale: 'zh-TW',
+  messages: {
+    'zh-TW': {
+      status: {
+        current: '當前',
+        originalMachine: '原始機器',
+        openSSOCache: '開啟 SSO Cache 資料夾',
+      },
+      backup: {
+        create: '建立備份',
+        refresh: '刷新',
+      },
+      restore: {
+        original: '還原原始機器',
+      },
+      app: {
+        processing: '處理中...',
+      },
+      message: {
+        tokenExpiredTip: 'Token 已過期',
+      },
+    },
+  },
+})
+
+// 建立預設的 usageInfo
+const createDefaultUsageInfo = (overrides: Partial<CurrentUsageInfo> = {}): CurrentUsageInfo => ({
+  subscriptionTitle: 'KIRO PRO',
+  usageLimit: 1000,
+  currentUsage: 500,
+  balance: 500,
+  isLowBalance: false,
+  ...overrides,
+})
+
+// 建立預設的 activeBackup
+const createDefaultBackup = (overrides: Partial<BackupItem> = {}): BackupItem => ({
+  name: 'test-backup',
+  backupTime: '2024-01-01T00:00:00Z',
+  hasToken: true,
+  hasMachineId: true,
+  machineId: 'abc123def456',
+  provider: 'Github',
+  isCurrent: true,
+  isOriginalMachine: false,
+  isTokenExpired: false,
+  subscriptionTitle: 'KIRO PRO',
+  usageLimit: 1000,
+  currentUsage: 500,
+  balance: 500,
+  isLowBalance: false,
+  cachedAt: '2024-01-01T00:00:00Z',
+  folderId: '',
+  ...overrides,
+})
+
+// 建立預設 Props
+const createDefaultProps = (overrides = {}) => ({
+  currentEnvironmentName: 'Test Environment',
+  currentMachineId: 'abc123def456',
+  currentProvider: 'Github',
+  usageInfo: createDefaultUsageInfo(),
+  activeBackup: createDefaultBackup(),
+  isRefreshing: false,
+  isRestoring: false,
+  cooldownSeconds: 0,
+  ...overrides,
+})
+
+// 掛載組件的輔助函數
+const mountComponent = (props = {}) => {
+  return mount(CurrentStatusCard, {
+    props: createDefaultProps(props),
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: IconStub },
+    },
+  })
+}
+
+describe('CurrentStatusCard', () => {
+  // ============================================================================
+  // Task 8.1: Props 和 Events 測試
+  // ============================================================================
+
+  describe('Task 8.1: Props 和 Events', () => {
+    it('should accept all required props', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should emit refresh event when refresh button is clicked', async () => {
+      const wrapper = mountComponent()
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      await refreshBtn.trigger('click')
+      expect(wrapper.emitted('refresh')).toBeTruthy()
+    })
+
+    it('should emit create-backup event when create button is clicked', async () => {
+      const wrapper = mountComponent()
+      const createBtn = wrapper.find('[data-testid="create-backup-btn"]')
+      await createBtn.trigger('click')
+      expect(wrapper.emitted('create-backup')).toBeTruthy()
+    })
+
+    it('should emit restore-original event when restore button is clicked', async () => {
+      const wrapper = mountComponent()
+      const restoreBtn = wrapper.find('[data-testid="restore-original-btn"]')
+      await restoreBtn.trigger('click')
+      expect(wrapper.emitted('restore-original')).toBeTruthy()
+    })
+
+    it('should emit open-sso-cache event when provider icon is clicked', async () => {
+      const wrapper = mountComponent()
+      const providerIcon = wrapper.find('[data-testid="provider-icon"]')
+      await providerIcon.trigger('click')
+      expect(wrapper.emitted('open-sso-cache')).toBeTruthy()
+    })
+  })
+
+  // ============================================================================
+  // Task 8.2: 狀態顯示測試
+  // ============================================================================
+
+  describe('Task 8.2: 狀態顯示', () => {
+    it('should render current environment name', () => {
+      const wrapper = mountComponent({ currentEnvironmentName: 'My Environment' })
+      expect(wrapper.text()).toContain('My Environment')
+    })
+
+    it('should render "原始機器" when currentEnvironmentName is empty', () => {
+      const wrapper = mountComponent({ currentEnvironmentName: '' })
+      expect(wrapper.text()).toContain('原始機器')
+    })
+
+    it('should render current machine ID', () => {
+      const wrapper = mountComponent({ currentMachineId: 'xyz789' })
+      expect(wrapper.text()).toContain('xyz789')
+    })
+
+    it('should render subscription type badge', () => {
+      const wrapper = mountComponent({
+        usageInfo: createDefaultUsageInfo({ subscriptionTitle: 'KIRO PRO+' }),
+      })
+      expect(wrapper.text()).toContain('PRO+')
+    })
+
+    it('should render balance information', () => {
+      const wrapper = mountComponent({
+        usageInfo: createDefaultUsageInfo({ balance: 750, usageLimit: 1000 }),
+      })
+      expect(wrapper.text()).toContain('750')
+      expect(wrapper.text()).toContain('1,000')
+    })
+
+    it('should show low balance warning when isLowBalance is true', () => {
+      const wrapper = mountComponent({
+        usageInfo: createDefaultUsageInfo({ isLowBalance: true }),
+      })
+      // 應該顯示警告圖標
+      const alertIcon = wrapper.find('[data-name="AlertTriangle"]')
+      expect(alertIcon.exists()).toBe(true)
+    })
+
+    it('should render Github provider icon when provider is Github', () => {
+      const wrapper = mountComponent({
+        activeBackup: createDefaultBackup({ provider: 'Github' }),
+      })
+      const providerIcon = wrapper.find('[data-testid="provider-icon"] [data-name="Github"]')
+      expect(providerIcon.exists()).toBe(true)
+    })
+
+    it('should render AWS provider icon when provider is AWS', () => {
+      const wrapper = mountComponent({
+        activeBackup: createDefaultBackup({ provider: 'AWS' }),
+      })
+      const providerIcon = wrapper.find('[data-testid="provider-icon"] [data-name="AWS"]')
+      expect(providerIcon.exists()).toBe(true)
+    })
+
+    it('should render Google provider icon when provider is Google', () => {
+      const wrapper = mountComponent({
+        activeBackup: createDefaultBackup({ provider: 'Google' }),
+      })
+      const providerIcon = wrapper.find('[data-testid="provider-icon"] [data-name="Google"]')
+      expect(providerIcon.exists()).toBe(true)
+    })
+
+    it('should use currentProvider when activeBackup is null', () => {
+      const wrapper = mountComponent({
+        activeBackup: null,
+        currentProvider: 'AWS',
+      })
+      const providerIcon = wrapper.find('[data-testid="provider-icon"] [data-name="AWS"]')
+      expect(providerIcon.exists()).toBe(true)
+    })
+  })
+
+  // ============================================================================
+  // Task 8.3: 刷新按鈕測試
+  // ============================================================================
+
+  describe('Task 8.3: 刷新按鈕', () => {
+    it('should show spinning icon when isRefreshing is true', () => {
+      const wrapper = mountComponent({ isRefreshing: true })
+      // 刷新按鈕內應該有 RefreshCw 圖標
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      expect(refreshBtn.find('[data-name="RefreshCw"]').exists()).toBe(true)
+      // 按鈕應該有 cursor-wait 類別
+      expect(refreshBtn.classes()).toContain('cursor-wait')
+    })
+
+    it('should show countdown when cooldownSeconds > 0', () => {
+      const wrapper = mountComponent({ cooldownSeconds: 30 })
+      expect(wrapper.text()).toContain('30')
+    })
+
+    it('should disable refresh button when cooldownSeconds > 0', () => {
+      const wrapper = mountComponent({ cooldownSeconds: 30 })
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      expect(refreshBtn.attributes('disabled')).toBeDefined()
+    })
+
+    it('should not emit refresh event when button is disabled', async () => {
+      const wrapper = mountComponent({ cooldownSeconds: 30 })
+      const refreshBtn = wrapper.find('[data-testid="refresh-btn"]')
+      await refreshBtn.trigger('click')
+      expect(wrapper.emitted('refresh')).toBeFalsy()
+    })
+  })
+
+  // ============================================================================
+  // Task 8.4: 操作按鈕測試
+  // ============================================================================
+
+  describe('Task 8.4: 操作按鈕', () => {
+    it('should render create backup button', () => {
+      const wrapper = mountComponent()
+      const createBtn = wrapper.find('[data-testid="create-backup-btn"]')
+      expect(createBtn.exists()).toBe(true)
+      expect(wrapper.text()).toContain('建立備份')
+    })
+
+    it('should render restore original button', () => {
+      const wrapper = mountComponent()
+      const restoreBtn = wrapper.find('[data-testid="restore-original-btn"]')
+      expect(restoreBtn.exists()).toBe(true)
+      expect(wrapper.text()).toContain('還原原始機器')
+    })
+
+    it('should show loading state when isRestoring is true', () => {
+      const wrapper = mountComponent({ isRestoring: true })
+      const restoreBtn = wrapper.find('[data-testid="restore-original-btn"]')
+      // 應該顯示 Rotate 圖標
+      expect(restoreBtn.find('[data-name="Rotate"]').exists()).toBe(true)
+      // 按鈕應該有 cursor-wait 類別
+      expect(restoreBtn.classes()).toContain('cursor-wait')
+      // 應該顯示處理中文字
+      expect(wrapper.text()).toContain('處理中')
+    })
+
+    it('should disable restore button when isRestoring is true', () => {
+      const wrapper = mountComponent({ isRestoring: true })
+      const restoreBtn = wrapper.find('[data-testid="restore-original-btn"]')
+      expect(restoreBtn.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  // ============================================================================
+  // 邊界情況測試
+  // ============================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle null usageInfo gracefully', () => {
+      const wrapper = mountComponent({ usageInfo: null })
+      expect(wrapper.exists()).toBe(true)
+      // 不應該顯示訂閱類型和餘額
+      expect(wrapper.find('[data-testid="subscription-badge"]').exists()).toBe(false)
+    })
+
+    it('should handle empty currentMachineId', () => {
+      const wrapper = mountComponent({ currentMachineId: '' })
+      expect(wrapper.text()).toContain('-')
+    })
+  })
+})

--- a/frontend/src/components/__tests__/FolderTree.spec.ts
+++ b/frontend/src/components/__tests__/FolderTree.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * FolderTree 組件測試
+ * @description 測試文件夾樹狀結構組件的渲染和事件處理
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import FolderTree from '../FolderTree.vue'
+import type { FolderItem, BackupItem } from '@/types/backup'
+
+// 建立測試用 i18n 實例
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      folder: {
+        rename: 'Rename',
+        delete: 'Delete',
+        emptyFolder: 'Empty folder',
+        uncategorized: 'Uncategorized',
+      },
+      backup: {
+        noBackups: 'No backups',
+      },
+    },
+  },
+})
+
+// Mock Icon component
+const IconStub = {
+  name: 'Icon',
+  template: '<span class="icon-stub" :data-name="name"></span>',
+  props: ['name'],
+}
+
+// Mock BackupCard component
+const BackupCardStub = {
+  name: 'BackupCard',
+  template: '<div class="backup-card-stub" :data-name="backup.name"></div>',
+  props: ['backup', 'isSelected', 'isSwitching', 'isDeleting', 'isRefreshing', 'isRegenerating', 'cooldownSeconds', 'copiedMachineId'],
+  emits: ['select', 'switch', 'delete', 'refresh', 'regenerate-id', 'copy-machine-id', 'drag-start', 'drag-end'],
+}
+
+// 建立預設的 folder 物件
+const createDefaultFolder = (overrides: Partial<FolderItem> = {}): FolderItem => ({
+  id: 'folder-1',
+  name: 'Test Folder',
+  createdAt: '2024-01-01T00:00:00Z',
+  order: 0,
+  snapshotCount: 2,
+  ...overrides,
+})
+
+// 建立預設的 backup 物件
+const createDefaultBackup = (overrides: Partial<BackupItem> = {}): BackupItem => ({
+  name: 'test-backup',
+  backupTime: '2024-01-01T00:00:00Z',
+  hasToken: true,
+  hasMachineId: true,
+  machineId: 'abc123def456',
+  provider: 'Github',
+  isCurrent: false,
+  isOriginalMachine: false,
+  isTokenExpired: false,
+  subscriptionTitle: 'KIRO PRO',
+  usageLimit: 1000,
+  currentUsage: 500,
+  balance: 500,
+  isLowBalance: false,
+  cachedAt: '2024-01-01T00:00:00Z',
+  folderId: '',
+  ...overrides,
+})
+
+// 建立預設的 props
+const createDefaultProps = (overrides = {}) => ({
+  folders: [] as FolderItem[],
+  backups: [] as BackupItem[],
+  expandedFolders: new Set<string>(),
+  uncategorizedExpanded: true,
+  dragOverFolderId: null as string | null,
+  dragOverUncategorized: false,
+  renamingFolder: null as string | null,
+  renameFolderName: '',
+  deletingFolder: null as string | null,
+  selectedBackups: new Set<string>(),
+  switchingBackup: null as string | null,
+  deletingBackup: null as string | null,
+  refreshingBackup: null as string | null,
+  regeneratingId: null as string | null,
+  countdownTimers: {} as Record<string, number>,
+  copiedMachineId: null as string | null,
+  ...overrides,
+})
+
+// 建立 wrapper 的輔助函數
+const createWrapper = (props = {}) => {
+  return mount(FolderTree, {
+    props: createDefaultProps(props),
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: IconStub, BackupCard: BackupCardStub },
+    },
+  })
+}
+
+describe('FolderTree', () => {
+  // ============================================================================
+  // Task 6.1: Props 渲染測試
+  // ============================================================================
+  describe('Task 6.1: Props 渲染', () => {
+    it('should render empty state when no folders and backups', () => {
+      const wrapper = createWrapper()
+      
+      // 應該渲染未分類區域
+      expect(wrapper.find('[data-testid="uncategorized-section"]').exists()).toBe(true)
+    })
+
+    it('should render folders list', () => {
+      const folders = [
+        createDefaultFolder({ id: 'folder-1', name: 'Folder 1' }),
+        createDefaultFolder({ id: 'folder-2', name: 'Folder 2' }),
+      ]
+      
+      const wrapper = createWrapper({ folders })
+      
+      expect(wrapper.text()).toContain('Folder 1')
+      expect(wrapper.text()).toContain('Folder 2')
+    })
+
+    it('should show expanded folder content', () => {
+      const folders = [createDefaultFolder({ id: 'folder-1', name: 'Test Folder' })]
+      const backups = [createDefaultBackup({ name: 'backup-1', folderId: 'folder-1' })]
+      const expandedFolders = new Set(['folder-1'])
+      
+      const wrapper = createWrapper({ folders, backups, expandedFolders })
+      
+      // 展開的文件夾應該顯示內容
+      expect(wrapper.find('[data-testid="folder-content-folder-1"]').exists()).toBe(true)
+    })
+
+    it('should show rename input when renamingFolder is set', () => {
+      const folders = [createDefaultFolder({ id: 'folder-1', name: 'Test Folder' })]
+      
+      const wrapper = createWrapper({ 
+        folders, 
+        renamingFolder: 'folder-1',
+        renameFolderName: 'New Name',
+      })
+      
+      const input = wrapper.find('[data-testid="rename-input-folder-1"]')
+      expect(input.exists()).toBe(true)
+    })
+
+    it('should highlight folder when dragOverFolderId matches', () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ folders, dragOverFolderId: 'folder-1' })
+      
+      const folderEl = wrapper.find('[data-testid="folder-folder-1"]')
+      expect(folderEl.classes()).toContain('ring-2')
+    })
+  })
+
+  // ============================================================================
+  // Task 6.2: 計算屬性測試
+  // ============================================================================
+  describe('Task 6.2: 計算屬性', () => {
+    it('should compute uncategorizedBackups correctly', () => {
+      const backups = [
+        createDefaultBackup({ name: 'backup-1', folderId: 'folder-1' }),
+        createDefaultBackup({ name: 'backup-2', folderId: '' }),
+        createDefaultBackup({ name: 'backup-3', folderId: '' }),
+      ]
+      
+      const wrapper = createWrapper({ backups, uncategorizedExpanded: true })
+      
+      // 應該顯示 2 個未分類的備份
+      const uncategorizedCards = wrapper.findAll('[data-testid="uncategorized-section"] .backup-card-stub')
+      expect(uncategorizedCards.length).toBe(2)
+    })
+
+    it('should compute isAllSelected correctly when all uncategorized are selected', () => {
+      const backups = [
+        createDefaultBackup({ name: 'backup-1', folderId: '' }),
+        createDefaultBackup({ name: 'backup-2', folderId: '' }),
+      ]
+      const selectedBackups = new Set(['backup-1', 'backup-2'])
+      
+      const wrapper = createWrapper({ backups, selectedBackups })
+      
+      const selectAllCheckbox = wrapper.find('[data-testid="select-all-checkbox"]')
+      expect((selectAllCheckbox.element as HTMLInputElement).checked).toBe(true)
+    })
+
+    it('should compute isAllSelected as false when not all selected', () => {
+      const backups = [
+        createDefaultBackup({ name: 'backup-1', folderId: '' }),
+        createDefaultBackup({ name: 'backup-2', folderId: '' }),
+      ]
+      const selectedBackups = new Set(['backup-1'])
+      
+      const wrapper = createWrapper({ backups, selectedBackups })
+      
+      const selectAllCheckbox = wrapper.find('[data-testid="select-all-checkbox"]')
+      expect((selectAllCheckbox.element as HTMLInputElement).checked).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // Task 6.3-6.7: 事件觸發測試
+  // ============================================================================
+  describe('Task 6.3-6.7: 事件觸發', () => {
+    it('should emit toggle-folder when folder header is clicked', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ folders })
+      
+      await wrapper.find('[data-testid="folder-header-folder-1"]').trigger('click')
+      
+      expect(wrapper.emitted('toggle-folder')).toBeTruthy()
+      expect(wrapper.emitted('toggle-folder')![0]).toEqual(['folder-1'])
+    })
+
+    it('should emit toggle-uncategorized when uncategorized header is clicked', async () => {
+      const wrapper = createWrapper()
+      
+      await wrapper.find('[data-testid="uncategorized-header"]').trigger('click')
+      
+      expect(wrapper.emitted('toggle-uncategorized')).toBeTruthy()
+    })
+
+    it('should emit start-rename-folder when rename button is clicked', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1', name: 'Test' })]
+      
+      const wrapper = createWrapper({ folders })
+      
+      await wrapper.find('[data-testid="rename-btn-folder-1"]').trigger('click')
+      
+      expect(wrapper.emitted('start-rename-folder')).toBeTruthy()
+      expect(wrapper.emitted('start-rename-folder')![0]).toEqual([folders[0]])
+    })
+
+    it('should emit confirm-rename-folder when confirm button is clicked', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ 
+        folders, 
+        renamingFolder: 'folder-1',
+        renameFolderName: 'New Name',
+      })
+      
+      await wrapper.find('[data-testid="confirm-rename-btn-folder-1"]').trigger('click')
+      
+      expect(wrapper.emitted('confirm-rename-folder')).toBeTruthy()
+    })
+
+    it('should emit cancel-rename-folder when cancel button is clicked', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ 
+        folders, 
+        renamingFolder: 'folder-1',
+        renameFolderName: 'New Name',
+      })
+      
+      await wrapper.find('[data-testid="cancel-rename-btn-folder-1"]').trigger('click')
+      
+      expect(wrapper.emitted('cancel-rename-folder')).toBeTruthy()
+    })
+
+    it('should emit delete-folder when delete button is clicked', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ folders })
+      
+      await wrapper.find('[data-testid="delete-btn-folder-1"]').trigger('click')
+      
+      expect(wrapper.emitted('delete-folder')).toBeTruthy()
+      expect(wrapper.emitted('delete-folder')![0]).toEqual([folders[0]])
+    })
+
+    it('should emit toggle-select-all when select all checkbox is changed', async () => {
+      const backups = [createDefaultBackup({ name: 'backup-1', folderId: '' })]
+      
+      const wrapper = createWrapper({ backups })
+      
+      await wrapper.find('[data-testid="select-all-checkbox"]').trigger('change')
+      
+      expect(wrapper.emitted('toggle-select-all')).toBeTruthy()
+    })
+
+    it('should emit drag-enter-folder on dragenter', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ folders })
+      
+      await wrapper.find('[data-testid="folder-folder-1"]').trigger('dragenter')
+      
+      expect(wrapper.emitted('drag-enter-folder')).toBeTruthy()
+      expect(wrapper.emitted('drag-enter-folder')![0]).toEqual(['folder-1'])
+    })
+
+    it('should emit drag-leave-folder on dragleave', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ folders })
+      
+      await wrapper.find('[data-testid="folder-folder-1"]').trigger('dragleave')
+      
+      expect(wrapper.emitted('drag-leave-folder')).toBeTruthy()
+    })
+
+    it('should emit drop-to-folder on drop', async () => {
+      const folders = [createDefaultFolder({ id: 'folder-1' })]
+      
+      const wrapper = createWrapper({ folders })
+      
+      const mockEvent = new Event('drop') as DragEvent
+      await wrapper.find('[data-testid="folder-folder-1"]').trigger('drop', mockEvent)
+      
+      expect(wrapper.emitted('drop-to-folder')).toBeTruthy()
+    })
+
+    it('should emit drag-enter-uncategorized on dragenter', async () => {
+      const wrapper = createWrapper()
+      
+      await wrapper.find('[data-testid="uncategorized-section"]').trigger('dragenter')
+      
+      expect(wrapper.emitted('drag-enter-uncategorized')).toBeTruthy()
+    })
+
+    it('should emit drop-to-uncategorized on drop', async () => {
+      const wrapper = createWrapper()
+      
+      const mockEvent = new Event('drop') as DragEvent
+      await wrapper.find('[data-testid="uncategorized-section"]').trigger('drop', mockEvent)
+      
+      expect(wrapper.emitted('drop-to-uncategorized')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/components/__tests__/SoftResetCard.spec.ts
+++ b/frontend/src/components/__tests__/SoftResetCard.spec.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SoftResetCard from '../SoftResetCard.vue'
+import type { SoftResetStatus } from '@/types/backup'
+
+// Mock vue-i18n
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'status.patchStatus': 'PATCH 狀態',
+        'status.patched': '已 Patch',
+        'status.notPatched': '未 Patch',
+        'status.patching': 'Patch 中...',
+        'status.clickToPatch': '點擊執行 Patch',
+        'status.hasCustomId': '使用自訂 ID',
+        'status.noCustomId': '使用系統 ID',
+        'status.openFolder': '打開文件夾',
+        'status.softResetActive': '一鍵新機已啟用',
+        'status.softResetInactive': '一鍵新機未啟用',
+        'restore.reset': '一鍵新機',
+        'restore.resetDesc': '產生新的機器指紋 ID',
+        'restore.original': '還原出廠',
+        'app.processing': '處理中...',
+        'message.successChange': '切換成功',
+      }
+      return translations[key] || key
+    },
+  }),
+}))
+
+// Mock Icon component
+const IconStub = {
+  name: 'Icon',
+  template: '<span class="icon-stub" :data-name="name"></span>',
+  props: ['name'],
+}
+
+// 建立預設的 SoftResetStatus
+const createDefaultStatus = (overrides: Partial<SoftResetStatus> = {}): SoftResetStatus => ({
+  isPatched: false,
+  hasCustomId: false,
+  customMachineId: '',
+  extensionPath: '/path/to/extension',
+  isSupported: true,
+  ...overrides,
+})
+
+// 建立預設的 props
+const createDefaultProps = (overrides = {}) => ({
+  softResetStatus: createDefaultStatus(),
+  isResetting: false,
+  isPatching: false,
+  ...overrides,
+})
+
+describe('Feature: ui-component-extraction, SoftResetCard Component', () => {
+  // ============================================================================
+  // Task 10.1: 組件骨架測試
+  // ============================================================================
+
+  describe('Task 10.1: 組件骨架', () => {
+    it('should render without errors', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should accept softResetStatus prop', () => {
+      const status = createDefaultStatus({ isPatched: true })
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({ softResetStatus: status }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should accept isResetting prop', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({ isResetting: true }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should accept isPatching prop', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({ isPatching: true }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
+
+  // ============================================================================
+  // Task 10.2: 狀態顯示測試
+  // ============================================================================
+
+  describe('Task 10.2: 狀態顯示', () => {
+    it('should render "已 Patch" label when isPatched is true', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="patched-label"]').exists()).toBe(true)
+    })
+
+    it('should render Machine ID status with custom ID', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ hasCustomId: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="machine-id-status"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('使用自訂 ID')
+    })
+
+    it('should render Machine ID status without custom ID', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ hasCustomId: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="machine-id-status"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('使用系統 ID')
+    })
+
+    it('should render green status indicator when both patched and hasCustomId', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: true, hasCustomId: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const indicator = wrapper.find('[data-testid="status-indicator"]')
+      expect(indicator.exists()).toBe(true)
+      expect(indicator.classes()).toContain('bg-app-success')
+    })
+
+    it('should render gray status indicator when not fully active', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: false, hasCustomId: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const indicator = wrapper.find('[data-testid="status-indicator"]')
+      expect(indicator.exists()).toBe(true)
+      expect(indicator.classes()).toContain('bg-zinc-500')
+    })
+
+    it('should render extension folder button when extensionPath exists', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ extensionPath: '/some/path' }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="open-extension-folder-btn"]').exists()).toBe(true)
+    })
+
+    it('should render machine id folder button', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="open-machine-id-folder-btn"]').exists()).toBe(true)
+    })
+  })
+
+  // ============================================================================
+  // Task 10.3: 一鍵新機按鈕測試
+  // ============================================================================
+
+  describe('Task 10.3: 一鍵新機按鈕', () => {
+    it('should render reset button', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="reset-btn"]').exists()).toBe(true)
+    })
+
+    it('should render SVG icon in reset button', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const resetBtn = wrapper.find('[data-testid="reset-btn"]')
+      expect(resetBtn.find('svg').exists()).toBe(true)
+    })
+
+    it('should show loading animation when isResetting is true', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({ isResetting: true }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const resetBtn = wrapper.find('[data-testid="reset-btn"]')
+      expect(resetBtn.find('animateTransform').exists()).toBe(true)
+    })
+
+    it('should emit reset event when reset button is clicked', async () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      await wrapper.find('[data-testid="reset-btn"]').trigger('click')
+      expect(wrapper.emitted('reset')).toBeTruthy()
+    })
+
+    it('should disable reset button when isResetting is true', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({ isResetting: true }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const resetBtn = wrapper.find('[data-testid="reset-btn"]')
+      expect(resetBtn.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  // ============================================================================
+  // Task 10.4: Patch 按鈕測試
+  // ============================================================================
+
+  describe('Task 10.4: Patch 按鈕', () => {
+    it('should render patch button when not patched', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="patch-btn"]').exists()).toBe(true)
+    })
+
+    it('should not render patch button when already patched', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="patch-btn"]').exists()).toBe(false)
+    })
+
+    it('should show loading state when isPatching is true', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: false }),
+          isPatching: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const patchBtn = wrapper.find('[data-testid="patch-btn"]')
+      expect(patchBtn.text()).toContain('Patch 中...')
+    })
+
+    it('should emit patch event when patch button is clicked', async () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      await wrapper.find('[data-testid="patch-btn"]').trigger('click')
+      expect(wrapper.emitted('patch')).toBeTruthy()
+    })
+
+    it('should disable patch button when isPatching is true', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ isPatched: false }),
+          isPatching: true,
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const patchBtn = wrapper.find('[data-testid="patch-btn"]')
+      expect(patchBtn.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  // ============================================================================
+  // Task 10.5: 還原按鈕測試
+  // ============================================================================
+
+  describe('Task 10.5: 還原按鈕', () => {
+    it('should render restore button', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      expect(wrapper.find('[data-testid="restore-btn"]').exists()).toBe(true)
+    })
+
+    it('should emit restore event when restore button is clicked', async () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ hasCustomId: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      await wrapper.find('[data-testid="restore-btn"]').trigger('click')
+      expect(wrapper.emitted('restore')).toBeTruthy()
+    })
+
+    it('should disable restore button when hasCustomId is false', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ hasCustomId: false }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const restoreBtn = wrapper.find('[data-testid="restore-btn"]')
+      expect(restoreBtn.attributes('disabled')).toBeDefined()
+    })
+
+    it('should enable restore button when hasCustomId is true', () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ hasCustomId: true }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      const restoreBtn = wrapper.find('[data-testid="restore-btn"]')
+      expect(restoreBtn.attributes('disabled')).toBeUndefined()
+    })
+  })
+
+  // ============================================================================
+  // 事件發射測試
+  // ============================================================================
+
+  describe('Events', () => {
+    it('should emit open-extension-folder event when extension folder button is clicked', async () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps({
+          softResetStatus: createDefaultStatus({ extensionPath: '/some/path' }),
+        }),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      await wrapper.find('[data-testid="open-extension-folder-btn"]').trigger('click')
+      expect(wrapper.emitted('open-extension-folder')).toBeTruthy()
+    })
+
+    it('should emit open-machine-id-folder event when machine id folder button is clicked', async () => {
+      const wrapper = mount(SoftResetCard, {
+        props: createDefaultProps(),
+        global: {
+          stubs: { Icon: IconStub },
+        },
+      })
+      await wrapper.find('[data-testid="open-machine-id-folder-btn"]').trigger('click')
+      expect(wrapper.emitted('open-machine-id-folder')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/components/settings/AutoSwitchTab.vue
+++ b/frontend/src/components/settings/AutoSwitchTab.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SettingsCard from './SettingsCard.vue'
 import RefreshIntervalCard from './RefreshIntervalCard.vue'
+import NumberInput from '@/components/NumberInput.vue'
 import { getVisibleCards, type AutoSwitchCardConfig } from '@/constants/autoSwitchCards'
 import { useRefreshIntervals } from '@/composables/useRefreshIntervals'
 import type { RefreshRule } from '@/types/refreshInterval'
@@ -148,27 +149,27 @@ const subscriptionTypes = ['Free', 'Pro', 'Pro+', 'Enterprise']
 
     <!-- 閾值設定卡片 -->
     <SettingsCard v-if="showThresholdCard" :title="t('autoSwitch.balanceThreshold')">
-      <div class="space-y-4">
+      <div class="space-y-6">
         <div>
-          <label class="text-sm text-zinc-400 block mb-2">{{ t('autoSwitch.balanceThresholdDesc') }}</label>
-          <input
-            type="number"
-            :value="balanceThreshold"
-            min="0"
-            max="100"
-            class="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100"
-            @input="emit('update:balanceThreshold', Number(($event.target as HTMLInputElement).value))"
+          <label class="text-sm text-zinc-400 block mb-3">{{ t('autoSwitch.balanceThresholdDesc') }}</label>
+          <NumberInput
+            :model-value="balanceThreshold"
+            :min="0"
+            :max="100"
+            :step="5"
+            min-width="min-w-[4rem]"
+            @update:model-value="emit('update:balanceThreshold', $event)"
           />
         </div>
         <div>
-          <label class="text-sm text-zinc-400 block mb-2">{{ t('autoSwitch.minTargetBalanceDesc') }}</label>
-          <input
-            type="number"
-            :value="minTargetBalance"
-            min="0"
-            max="1000"
-            class="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100"
-            @input="emit('update:minTargetBalance', Number(($event.target as HTMLInputElement).value))"
+          <label class="text-sm text-zinc-400 block mb-3">{{ t('autoSwitch.minTargetBalanceDesc') }}</label>
+          <NumberInput
+            :model-value="minTargetBalance"
+            :min="0"
+            :max="1000"
+            :step="10"
+            min-width="min-w-[4rem]"
+            @update:model-value="emit('update:minTargetBalance', $event)"
           />
         </div>
       </div>

--- a/frontend/src/components/settings/RefreshRuleItem.vue
+++ b/frontend/src/components/settings/RefreshRuleItem.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { RefreshRule } from '@/types/refreshInterval'
 import { REFRESH_INTERVAL_STYLES } from '@/constants/refreshIntervalStyles'
+import NumberInput from '@/components/NumberInput.vue'
 
 const props = withDefaults(defineProps<{
   rule: RefreshRule
@@ -56,30 +57,6 @@ const containerClass = computed(() => {
 
 
 /**
- * 處理 minBalance 輸入變更
- */
-function handleMinBalanceChange(event: Event) {
-  const value = Number((event.target as HTMLInputElement).value)
-  emit('update:minBalance', value)
-}
-
-/**
- * 處理 maxBalance 輸入變更
- */
-function handleMaxBalanceChange(event: Event) {
-  const value = Number((event.target as HTMLInputElement).value)
-  emit('update:maxBalance', value)
-}
-
-/**
- * 處理 interval 輸入變更
- */
-function handleIntervalChange(event: Event) {
-  const value = Number((event.target as HTMLInputElement).value)
-  emit('update:interval', value)
-}
-
-/**
  * 處理無上限 checkbox 變更
  */
 function handleUnlimitedChange(event: Event) {
@@ -103,26 +80,28 @@ function handleDelete() {
     data-testid="rule-row"
   >
     <!-- 餘額下限輸入 -->
-    <input
-      type="number"
-      :value="rule.minBalance"
-      :class="REFRESH_INTERVAL_STYLES.input.balance"
+    <NumberInput
+      :model-value="rule.minBalance"
+      :min="0"
+      :max="9999"
+      :step="10"
+      min-width="min-w-[4rem]"
       data-testid="min-balance-input"
-      min="0"
-      @input="handleMinBalanceChange"
+      @update:model-value="emit('update:minBalance', $event)"
     />
     
     <span :class="REFRESH_INTERVAL_STYLES.arrow">~</span>
     
     <!-- 餘額上限輸入 -->
-    <input
-      type="number"
-      :value="rule.maxBalance"
-      :class="REFRESH_INTERVAL_STYLES.input.balance"
+    <NumberInput
+      :model-value="isUnlimited ? 0 : rule.maxBalance"
+      :min="0"
+      :max="9999"
+      :step="10"
       :disabled="isUnlimited"
+      min-width="min-w-[4rem]"
       data-testid="max-balance-input"
-      min="0"
-      @input="handleMaxBalanceChange"
+      @update:model-value="emit('update:maxBalance', $event)"
     />
     
     <!-- 無上限 checkbox -->
@@ -140,13 +119,14 @@ function handleDelete() {
     <span :class="REFRESH_INTERVAL_STYLES.arrow">→</span>
     
     <!-- 間隔輸入 -->
-    <input
-      type="number"
-      :value="rule.interval"
-      :class="REFRESH_INTERVAL_STYLES.input.interval"
+    <NumberInput
+      :model-value="rule.interval"
+      :min="1"
+      :max="60"
+      :step="1"
+      min-width="min-w-[4rem]"
       data-testid="interval-input"
-      min="1"
-      @input="handleIntervalChange"
+      @update:model-value="emit('update:interval', $event)"
     />
     
     <span class="text-sm text-zinc-400">{{ t('refreshInterval.minutes') }}</span>

--- a/frontend/src/composables/__tests__/arbitraries.spec.ts
+++ b/frontend/src/composables/__tests__/arbitraries.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * 測試數據生成器驗證
+ * @description 確保所有 arbitrary 生成器能正確產生符合類型的數據
+ */
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import {
+  backupItemArbitrary,
+  folderItemArbitrary,
+  currentUsageInfoArbitrary,
+  appSettingsArbitrary,
+  autoSwitchSettingsArbitrary,
+  autoSwitchStatusArbitrary,
+  pathDetectionResultArbitrary,
+  resultArbitrary,
+  consistentBackupItemArbitrary,
+  backupListArbitrary,
+  folderListArbitrary,
+} from './arbitraries'
+
+describe('Arbitraries - 測試數據生成器', () => {
+  describe('backupItemArbitrary', () => {
+    it('應生成有效的 BackupItem', () => {
+      fc.assert(
+        fc.property(backupItemArbitrary, (item) => {
+          expect(item).toHaveProperty('name')
+          expect(item).toHaveProperty('backupTime')
+          expect(item).toHaveProperty('hasToken')
+          expect(item).toHaveProperty('balance')
+          expect(typeof item.name).toBe('string')
+          expect(typeof item.hasToken).toBe('boolean')
+          expect(typeof item.balance).toBe('number')
+          return true
+        }),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('folderItemArbitrary', () => {
+    it('應生成有效的 FolderItem', () => {
+      fc.assert(
+        fc.property(folderItemArbitrary, (item) => {
+          expect(item).toHaveProperty('id')
+          expect(item).toHaveProperty('name')
+          expect(item).toHaveProperty('order')
+          expect(typeof item.id).toBe('string')
+          expect(typeof item.order).toBe('number')
+          expect(item.order).toBeGreaterThanOrEqual(0)
+          return true
+        }),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('currentUsageInfoArbitrary', () => {
+    it('應生成有效的 CurrentUsageInfo', () => {
+      fc.assert(
+        fc.property(currentUsageInfoArbitrary, (info) => {
+          expect(info).toHaveProperty('subscriptionTitle')
+          expect(info).toHaveProperty('usageLimit')
+          expect(info).toHaveProperty('currentUsage')
+          expect(info).toHaveProperty('balance')
+          expect(info).toHaveProperty('isLowBalance')
+          expect(typeof info.usageLimit).toBe('number')
+          expect(info.usageLimit).toBeGreaterThanOrEqual(0)
+          return true
+        }),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('consistentBackupItemArbitrary', () => {
+    it('應生成用量數據一致的 BackupItem (balance = usageLimit - currentUsage)', () => {
+      fc.assert(
+        fc.property(consistentBackupItemArbitrary, (item) => {
+          const expectedBalance = item.usageLimit - item.currentUsage
+          // 允許浮點數誤差
+          expect(Math.abs(item.balance - expectedBalance)).toBeLessThan(0.01)
+          expect(item.currentUsage).toBeLessThanOrEqual(item.usageLimit)
+          return true
+        }),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('backupListArbitrary', () => {
+    it('withCurrentItem=true 時應確保只有一個 isCurrent=true', () => {
+      fc.assert(
+        fc.property(backupListArbitrary({ minLength: 2, maxLength: 5, withCurrentItem: true }), (list) => {
+          const currentItems = list.filter(item => item.isCurrent)
+          expect(currentItems.length).toBeLessThanOrEqual(1)
+          return true
+        }),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('autoSwitchStatusArbitrary', () => {
+    it('status 應為有效值', () => {
+      fc.assert(
+        fc.property(autoSwitchStatusArbitrary, (status) => {
+          expect(['stopped', 'running', 'cooldown']).toContain(status.status)
+          expect(status.cooldownRemaining).toBeGreaterThanOrEqual(0)
+          return true
+        }),
+        { numRuns: 20 }
+      )
+    })
+  })
+})

--- a/frontend/src/composables/__tests__/arbitraries.ts
+++ b/frontend/src/composables/__tests__/arbitraries.ts
@@ -1,0 +1,314 @@
+/**
+ * 測試數據生成器
+ * @description 使用 fast-check 為 Property-Based Testing 提供任意值生成器
+ * @see https://fast-check.dev/
+ */
+import * as fc from 'fast-check'
+import type {
+  BackupItem,
+  FolderItem,
+  CurrentUsageInfo,
+  AppSettings,
+  AutoSwitchSettings,
+  AutoSwitchStatus,
+  RefreshIntervalRule,
+  PathDetectionResult,
+  Result,
+  SoftResetStatus,
+} from '@/types/backup'
+
+// ============================================================================
+// 基礎生成器
+// ============================================================================
+
+/**
+ * 生成有效的快照名稱
+ * @description 符合命名規則的字串（非空、無非法字元）
+ */
+export const snapshotNameArbitrary = fc.stringMatching(/^[a-zA-Z0-9\u4e00-\u9fff_-]{1,50}$/)
+
+/**
+ * 生成 RFC3339 格式的時間字串
+ */
+export const rfc3339DateArbitrary = fc.integer({
+  min: new Date('2020-01-01').getTime(),
+  max: new Date('2030-12-31').getTime(),
+}).map(ts => new Date(ts).toISOString())
+
+/**
+ * 生成 UUID 格式的字串
+ */
+export const uuidArbitrary = fc.uuid()
+
+/**
+ * 生成十六進制字串（用於 Machine ID）
+ */
+export const hexStringArbitrary = fc.array(
+  fc.integer({ min: 0, max: 15 }),
+  { minLength: 32, maxLength: 64 }
+).map(arr => arr.map(n => n.toString(16)).join(''))
+
+/**
+ * 生成認證提供者
+ */
+export const providerArbitrary = fc.constantFrom('aws', 'github', 'google', '')
+
+/**
+ * 生成訂閱類型
+ */
+export const subscriptionTypeArbitrary = fc.constantFrom(
+  'Free',
+  'Pro',
+  'Team',
+  'Enterprise',
+  ''
+)
+
+
+// ============================================================================
+// 用量相關生成器
+// ============================================================================
+
+/**
+ * 生成用量數值 (0 ~ 10000)
+ */
+export const usageValueArbitrary = fc.float({
+  min: 0,
+  max: 10000,
+  noNaN: true,
+})
+
+/**
+ * 生成餘額百分比 (0.0 ~ 1.0)
+ */
+export const balancePercentArbitrary = fc.float({
+  min: 0,
+  max: 1,
+  noNaN: true,
+})
+
+// ============================================================================
+// 核心介面生成器
+// ============================================================================
+
+/**
+ * BackupItem 生成器
+ * @description 生成完整的備份項目數據
+ */
+export const backupItemArbitrary: fc.Arbitrary<BackupItem> = fc.record({
+  name: snapshotNameArbitrary,
+  backupTime: rfc3339DateArbitrary,
+  hasToken: fc.boolean(),
+  hasMachineId: fc.boolean(),
+  machineId: hexStringArbitrary,
+  provider: providerArbitrary,
+  isCurrent: fc.boolean(),
+  isOriginalMachine: fc.boolean(),
+  isTokenExpired: fc.boolean(),
+  subscriptionTitle: subscriptionTypeArbitrary,
+  usageLimit: usageValueArbitrary,
+  currentUsage: usageValueArbitrary,
+  balance: usageValueArbitrary,
+  isLowBalance: fc.boolean(),
+  cachedAt: rfc3339DateArbitrary,
+  folderId: fc.oneof(uuidArbitrary, fc.constant('')),
+})
+
+/**
+ * FolderItem 生成器
+ * @description 生成完整的文件夾項目數據
+ */
+export const folderItemArbitrary: fc.Arbitrary<FolderItem> = fc.record({
+  id: uuidArbitrary,
+  name: fc.stringMatching(/^[a-zA-Z0-9\u4e00-\u9fff_-]{1,30}$/),
+  createdAt: rfc3339DateArbitrary,
+  order: fc.nat({ max: 100 }),
+  snapshotCount: fc.nat({ max: 50 }),
+})
+
+/**
+ * CurrentUsageInfo 生成器
+ * @description 生成當前用量資訊
+ */
+export const currentUsageInfoArbitrary: fc.Arbitrary<CurrentUsageInfo> = fc.record({
+  subscriptionTitle: subscriptionTypeArbitrary,
+  usageLimit: usageValueArbitrary,
+  currentUsage: usageValueArbitrary,
+  balance: usageValueArbitrary,
+  isLowBalance: fc.boolean(),
+})
+
+/**
+ * Result 生成器
+ * @description 生成操作結果
+ */
+export const resultArbitrary: fc.Arbitrary<Result> = fc.record({
+  success: fc.boolean(),
+  message: fc.string({ minLength: 0, maxLength: 200 }),
+})
+
+
+/**
+ * AppSettings 生成器
+ * @description 生成應用設定
+ */
+export const appSettingsArbitrary: fc.Arbitrary<AppSettings> = fc.record({
+  lowBalanceThreshold: balancePercentArbitrary,
+  kiroVersion: fc.stringMatching(/^\d+\.\d+\.\d+$/),
+  useAutoDetect: fc.boolean(),
+  customKiroInstallPath: fc.oneof(
+    fc.constant(''),
+    fc.constant('C:\\Program Files\\Kiro'),
+    fc.constant('/Applications/Kiro.app')
+  ),
+})
+
+/**
+ * RefreshIntervalRule 生成器
+ * @description 生成刷新間隔規則
+ */
+export const refreshIntervalRuleArbitrary: fc.Arbitrary<RefreshIntervalRule> = fc.record({
+  minBalance: fc.nat({ max: 1000 }),
+  maxBalance: fc.oneof(fc.nat({ max: 10000 }), fc.constant(-1)),
+  interval: fc.integer({ min: 1, max: 60 }),
+})
+
+/**
+ * AutoSwitchSettings 生成器
+ * @description 生成自動切換設定
+ */
+export const autoSwitchSettingsArbitrary: fc.Arbitrary<AutoSwitchSettings> = fc.record({
+  enabled: fc.boolean(),
+  balanceThreshold: usageValueArbitrary,
+  minTargetBalance: usageValueArbitrary,
+  folderIds: fc.array(uuidArbitrary, { maxLength: 5 }),
+  subscriptionTypes: fc.array(subscriptionTypeArbitrary, { maxLength: 4 }),
+  refreshIntervals: fc.array(refreshIntervalRuleArbitrary, { maxLength: 5 }),
+  notifyOnSwitch: fc.boolean(),
+  notifyOnLowBalance: fc.boolean(),
+})
+
+/**
+ * AutoSwitchStatus 生成器
+ * @description 生成自動切換狀態
+ */
+export const autoSwitchStatusArbitrary: fc.Arbitrary<AutoSwitchStatus> = fc.record({
+  status: fc.constantFrom('stopped', 'running', 'cooldown'),
+  lastBalance: usageValueArbitrary,
+  cooldownRemaining: fc.nat({ max: 300 }),
+  switchCount: fc.nat({ max: 100 }),
+})
+
+/**
+ * PathDetectionResult 生成器
+ * @description 生成路徑偵測結果
+ */
+export const pathDetectionResultArbitrary: fc.Arbitrary<PathDetectionResult> = fc.record({
+  path: fc.oneof(
+    fc.constant(''),
+    fc.constant('C:\\Program Files\\Kiro'),
+    fc.constant('/Applications/Kiro.app'),
+    fc.constant('/usr/local/bin/kiro')
+  ),
+  success: fc.boolean(),
+  triedStrategies: fc.option(fc.array(fc.string(), { maxLength: 5 }), { nil: undefined }),
+  failureReasons: fc.option(
+    fc.dictionary(fc.string(), fc.string()),
+    { nil: undefined }
+  ),
+})
+
+/**
+ * SoftResetStatus 生成器
+ * @description 生成軟重置狀態
+ */
+export const softResetStatusArbitrary: fc.Arbitrary<SoftResetStatus> = fc.record({
+  isPatched: fc.boolean(),
+  hasCustomId: fc.boolean(),
+  customMachineId: fc.oneof(hexStringArbitrary, fc.constant('')),
+  extensionPath: fc.oneof(
+    fc.constant(''),
+    fc.constant('C:\\Users\\user\\.kiro\\extensions'),
+    fc.constant('/home/user/.kiro/extensions'),
+    fc.constant('/Users/user/.kiro/extensions')
+  ),
+  isSupported: fc.boolean(),
+})
+
+
+// ============================================================================
+// 組合生成器（用於複雜測試場景）
+// ============================================================================
+
+/**
+ * 生成備份列表
+ * @param options 配置選項
+ * @description 確保生成的備份名稱唯一，避免 Property 測試中的名稱衝突
+ */
+export const backupListArbitrary = (options?: {
+  minLength?: number
+  maxLength?: number
+  withCurrentItem?: boolean
+}) => {
+  const { minLength = 0, maxLength = 10, withCurrentItem = false } = options ?? {}
+  
+  return fc.array(backupItemArbitrary, { minLength, maxLength }).map(items => {
+    // 確保名稱唯一：為重複名稱添加索引後綴
+    const nameCount = new Map<string, number>()
+    const uniqueItems = items.map((item) => {
+      const count = nameCount.get(item.name) || 0
+      nameCount.set(item.name, count + 1)
+      return {
+        ...item,
+        name: count === 0 ? item.name : `${item.name}_${count}`,
+      }
+    })
+    
+    if (withCurrentItem && uniqueItems.length > 0) {
+      // 確保只有一個 isCurrent = true（使用確定性方式）
+      return uniqueItems.map((item, index) => ({
+        ...item,
+        isCurrent: index === 0,
+      }))
+    }
+    return uniqueItems.map(item => ({ ...item, isCurrent: false }))
+  })
+}
+
+/**
+ * 生成文件夾列表
+ */
+export const folderListArbitrary = (options?: {
+  minLength?: number
+  maxLength?: number
+}) => {
+  const { minLength = 0, maxLength = 10 } = options ?? {}
+  return fc.array(folderItemArbitrary, { minLength, maxLength })
+}
+
+/**
+ * 生成一致的用量數據（currentUsage <= usageLimit, balance = usageLimit - currentUsage）
+ */
+export const consistentUsageArbitrary = fc.record({
+  usageLimit: fc.float({ min: 100, max: 10000, noNaN: true }),
+  usagePercent: fc.float({ min: 0, max: 1, noNaN: true }),
+}).map(({ usageLimit, usagePercent }) => {
+  const currentUsage = usageLimit * usagePercent
+  const balance = usageLimit - currentUsage
+  return {
+    usageLimit,
+    currentUsage,
+    balance,
+    isLowBalance: balance / usageLimit < 0.2,
+  }
+})
+
+/**
+ * 生成帶有一致用量的 BackupItem
+ */
+export const consistentBackupItemArbitrary: fc.Arbitrary<BackupItem> = fc
+  .tuple(backupItemArbitrary, consistentUsageArbitrary)
+  .map(([item, usage]) => ({
+    ...item,
+    ...usage,
+  }))

--- a/frontend/src/composables/__tests__/useAppSettings.spec.ts
+++ b/frontend/src/composables/__tests__/useAppSettings.spec.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useAppSettings } from '../useAppSettings'
+import type { AppSettings, Result } from '@/types/backup'
+
+// Mock window.go.main.App
+const mockApp = {
+  GetSettings: vi.fn(),
+  SaveSettings: vi.fn(),
+  GetDetectedKiroVersion: vi.fn(),
+  GetDetectedKiroInstallPath: vi.fn(),
+}
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+}
+
+// Mock useI18n
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    locale: { value: 'zh-TW' },
+  }),
+}))
+
+describe('Feature: app-vue-decoupling, useAppSettings composable', () => {
+  beforeEach(() => {
+    // Setup window.go mock
+    ;(window as any).go = {
+      main: {
+        App: mockApp,
+      },
+    }
+    // Setup localStorage mock
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    })
+    // Reset all mocks
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Property 24: 版本號保存與自動偵測互斥', () => {
+    it('saveKiroVersion 應關閉 useAutoDetect', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }).filter(s => s.trim().length > 0),
+          async (version) => {
+            // 每次迭代前重置 mock
+            mockApp.GetSettings.mockReset()
+            mockApp.SaveSettings.mockReset()
+            
+            // Arrange
+            const defaultSettings: AppSettings = {
+              lowBalanceThreshold: 0.2,
+              kiroVersion: '0.8.206',
+              useAutoDetect: true,
+              customKiroInstallPath: '',
+            }
+            mockApp.GetSettings.mockResolvedValue(defaultSettings)
+            mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+            const {
+              appSettings,
+              kiroVersionInput,
+              loadSettings,
+              saveKiroVersion,
+            } = useAppSettings()
+
+            await loadSettings()
+
+            // Act
+            kiroVersionInput.value = version
+            await saveKiroVersion()
+
+            // Assert: SaveSettings 應被調用，且 useAutoDetect 為 false
+            // 注意：實作中會對版本號進行 trim()
+            const expectedVersion = version.trim()
+            expect(mockApp.SaveSettings).toHaveBeenCalledWith(
+              expect.objectContaining({
+                kiroVersion: expectedVersion,
+                useAutoDetect: false,
+              })
+            )
+            return true
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('detectKiroVersion 應啟用 useAutoDetect', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }).filter(s => s.trim().length > 0),
+          async (detectedVersion) => {
+            // 每次迭代前重置 mock
+            mockApp.GetSettings.mockReset()
+            mockApp.GetDetectedKiroVersion.mockReset()
+            mockApp.SaveSettings.mockReset()
+            
+            // Arrange
+            const defaultSettings: AppSettings = {
+              lowBalanceThreshold: 0.2,
+              kiroVersion: '0.8.206',
+              useAutoDetect: false,
+              customKiroInstallPath: '',
+            }
+            mockApp.GetSettings.mockResolvedValue(defaultSettings)
+            mockApp.GetDetectedKiroVersion.mockResolvedValue({
+              success: true,
+              message: detectedVersion,
+            })
+            mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+            const {
+              appSettings,
+              loadSettings,
+              detectKiroVersion,
+            } = useAppSettings()
+
+            await loadSettings()
+
+            // Act
+            await detectKiroVersion()
+
+            // Assert: SaveSettings 應被調用，且 useAutoDetect 為 true
+            expect(mockApp.SaveSettings).toHaveBeenCalledWith(
+              expect.objectContaining({
+                kiroVersion: detectedVersion,
+                useAutoDetect: true,
+              })
+            )
+            return true
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  describe('Property 25: 安裝路徑清除', () => {
+    it('clearKiroInstallPath 應將 customKiroInstallPath 設為空字串', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 100 }).filter(s => s.trim().length > 0),
+          async (initialPath) => {
+            // 每次迭代前重置 mock
+            mockApp.GetSettings.mockReset()
+            mockApp.SaveSettings.mockReset()
+            
+            // Arrange
+            const defaultSettings: AppSettings = {
+              lowBalanceThreshold: 0.2,
+              kiroVersion: '0.8.206',
+              useAutoDetect: true,
+              customKiroInstallPath: initialPath,
+            }
+            mockApp.GetSettings.mockResolvedValue(defaultSettings)
+            mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+            const {
+              appSettings,
+              kiroInstallPathInput,
+              loadSettings,
+              clearKiroInstallPath,
+            } = useAppSettings()
+
+            await loadSettings()
+            expect(appSettings.value.customKiroInstallPath).toBe(initialPath)
+
+            // Act
+            await clearKiroInstallPath()
+
+            // Assert
+            expect(mockApp.SaveSettings).toHaveBeenCalledWith(
+              expect.objectContaining({
+                customKiroInstallPath: '',
+              })
+            )
+            expect(appSettings.value.customKiroInstallPath).toBe('')
+            expect(kiroInstallPathInput.value).toBe('')
+            return true
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  describe('Property 26: 低餘額閾值本地更新', () => {
+    it('saveLowBalanceThreshold 應更新本地 isLowBalance 狀態', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.float({ min: Math.fround(0.01), max: Math.fround(0.99), noNaN: true }),
+          fc.float({ min: Math.fround(0.01), max: Math.fround(0.99), noNaN: true }),
+          fc.integer({ min: 100, max: 1000 }),
+          async (oldThreshold, newThreshold, usageLimit) => {
+            // 每次迭代前重置 mock
+            mockApp.GetSettings.mockReset()
+            mockApp.SaveSettings.mockReset()
+            
+            // Arrange
+            const balance = usageLimit * 0.5 // 50% 餘額
+            const defaultSettings: AppSettings = {
+              lowBalanceThreshold: oldThreshold,
+              kiroVersion: '0.8.206',
+              useAutoDetect: true,
+              customKiroInstallPath: '',
+            }
+            mockApp.GetSettings.mockResolvedValue(defaultSettings)
+            mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+            const {
+              appSettings,
+              loadSettings,
+              saveLowBalanceThreshold,
+            } = useAppSettings()
+
+            await loadSettings()
+
+            // 模擬 backups 和 currentUsageInfo（這些會由外部傳入的回調處理）
+            let localIsLowBalanceUpdated = false
+            const mockUpdateCallback = (threshold: number) => {
+              localIsLowBalanceUpdated = true
+            }
+
+            // Act
+            await saveLowBalanceThreshold(newThreshold, mockUpdateCallback)
+
+            // Assert
+            expect(mockApp.SaveSettings).toHaveBeenCalledWith(
+              expect.objectContaining({
+                lowBalanceThreshold: newThreshold,
+              })
+            )
+            expect(appSettings.value.lowBalanceThreshold).toBe(newThreshold)
+            expect(localIsLowBalanceUpdated).toBe(true)
+            return true
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  describe('Property 27: 語言切換持久化', () => {
+    it('switchLanguage 應將語言設定存入 localStorage', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom('zh-TW', 'zh-CN', 'en'),
+          async (lang) => {
+            // Arrange
+            const { switchLanguage } = useAppSettings()
+
+            // Act
+            switchLanguage(lang)
+
+            // Assert
+            expect(localStorageMock.setItem).toHaveBeenCalledWith(
+              'kiro-manager-lang',
+              lang
+            )
+            return true
+          }
+        ),
+        { numRuns: 10 }
+      )
+    })
+  })
+
+  describe('Unit Tests', () => {
+    it('should initialize with default values', async () => {
+      const defaultSettings: AppSettings = {
+        lowBalanceThreshold: 0.2,
+        kiroVersion: '0.8.206',
+        useAutoDetect: true,
+        customKiroInstallPath: '',
+      }
+      mockApp.GetSettings.mockResolvedValue(defaultSettings)
+
+      const {
+        appSettings,
+        kiroVersionInput,
+        kiroVersionModified,
+        kiroInstallPathInput,
+        kiroInstallPathModified,
+        thresholdPreview,
+        detectingVersion,
+        detectingPath,
+        loadSettings,
+      } = useAppSettings()
+
+      await loadSettings()
+
+      expect(appSettings.value).toEqual(defaultSettings)
+      expect(kiroVersionInput.value).toBe('0.8.206')
+      expect(kiroVersionModified.value).toBe(false)
+      expect(kiroInstallPathInput.value).toBe('')
+      expect(kiroInstallPathModified.value).toBe(false)
+      expect(thresholdPreview.value).toBe(20)
+      expect(detectingVersion.value).toBe(false)
+      expect(detectingPath.value).toBe(false)
+    })
+
+    it('onKiroVersionInput should set kiroVersionModified to true', () => {
+      const { kiroVersionModified, onKiroVersionInput } = useAppSettings()
+
+      expect(kiroVersionModified.value).toBe(false)
+      onKiroVersionInput()
+      expect(kiroVersionModified.value).toBe(true)
+    })
+
+    it('onKiroInstallPathInput should set kiroInstallPathModified to true', () => {
+      const { kiroInstallPathModified, onKiroInstallPathInput } = useAppSettings()
+
+      expect(kiroInstallPathModified.value).toBe(false)
+      onKiroInstallPathInput()
+      expect(kiroInstallPathModified.value).toBe(true)
+    })
+
+    it('detectKiroVersion should set detectingVersion during detection', async () => {
+      const defaultSettings: AppSettings = {
+        lowBalanceThreshold: 0.2,
+        kiroVersion: '0.8.206',
+        useAutoDetect: false,
+        customKiroInstallPath: '',
+      }
+      mockApp.GetSettings.mockResolvedValue(defaultSettings)
+      
+      // 使用延遲來測試 loading 狀態
+      let resolveDetection: (value: Result) => void
+      mockApp.GetDetectedKiroVersion.mockReturnValue(
+        new Promise<Result>((resolve) => {
+          resolveDetection = resolve
+        })
+      )
+      mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { detectingVersion, loadSettings, detectKiroVersion } = useAppSettings()
+
+      await loadSettings()
+      expect(detectingVersion.value).toBe(false)
+
+      const detectPromise = detectKiroVersion()
+      expect(detectingVersion.value).toBe(true)
+
+      resolveDetection!({ success: true, message: '0.9.0' })
+      await detectPromise
+
+      expect(detectingVersion.value).toBe(false)
+    })
+
+    it('detectKiroInstallPath should set detectingPath during detection', async () => {
+      const defaultSettings: AppSettings = {
+        lowBalanceThreshold: 0.2,
+        kiroVersion: '0.8.206',
+        useAutoDetect: true,
+        customKiroInstallPath: '',
+      }
+      mockApp.GetSettings.mockResolvedValue(defaultSettings)
+      
+      let resolveDetection: (value: Result) => void
+      mockApp.GetDetectedKiroInstallPath.mockReturnValue(
+        new Promise<Result>((resolve) => {
+          resolveDetection = resolve
+        })
+      )
+      mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { detectingPath, loadSettings, detectKiroInstallPath } = useAppSettings()
+
+      await loadSettings()
+      expect(detectingPath.value).toBe(false)
+
+      const detectPromise = detectKiroInstallPath()
+      expect(detectingPath.value).toBe(true)
+
+      resolveDetection!({ success: true, message: 'C:\\Program Files\\Kiro' })
+      await detectPromise
+
+      expect(detectingPath.value).toBe(false)
+    })
+
+    it('saveKiroInstallPath should save custom path', async () => {
+      const defaultSettings: AppSettings = {
+        lowBalanceThreshold: 0.2,
+        kiroVersion: '0.8.206',
+        useAutoDetect: true,
+        customKiroInstallPath: '',
+      }
+      mockApp.GetSettings.mockResolvedValue(defaultSettings)
+      mockApp.SaveSettings.mockResolvedValue({ success: true, message: '' })
+
+      const {
+        appSettings,
+        kiroInstallPathInput,
+        kiroInstallPathModified,
+        loadSettings,
+        saveKiroInstallPath,
+      } = useAppSettings()
+
+      await loadSettings()
+
+      kiroInstallPathInput.value = 'D:\\Custom\\Kiro'
+      kiroInstallPathModified.value = true
+
+      await saveKiroInstallPath()
+
+      expect(mockApp.SaveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customKiroInstallPath: 'D:\\Custom\\Kiro',
+        })
+      )
+      expect(appSettings.value.customKiroInstallPath).toBe('D:\\Custom\\Kiro')
+      expect(kiroInstallPathModified.value).toBe(false)
+    })
+
+    it('checkPathDetectionStatus should return correct status', async () => {
+      const { checkPathDetectionStatus } = useAppSettings()
+
+      // 有自定義路徑
+      expect(checkPathDetectionStatus('C:\\Kiro', true)).toBe('custom')
+      
+      // 無自定義路徑，使用自動偵測
+      expect(checkPathDetectionStatus('', true)).toBe('auto')
+      
+      // 無自定義路徑，未使用自動偵測
+      expect(checkPathDetectionStatus('', false)).toBe('none')
+    })
+  })
+})

--- a/frontend/src/composables/__tests__/useAutoSwitch.spec.ts
+++ b/frontend/src/composables/__tests__/useAutoSwitch.spec.ts
@@ -1,0 +1,437 @@
+/**
+ * useAutoSwitch Composable 測試
+ * @description Property-Based Testing for 自動切換功能
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useAutoSwitch } from '../useAutoSwitch'
+import {
+  autoSwitchSettingsArbitrary,
+  autoSwitchStatusArbitrary,
+  refreshIntervalRuleArbitrary,
+} from './arbitraries'
+import type { AutoSwitchSettings, AutoSwitchStatus, RefreshIntervalRule } from '@/types/backup'
+
+// Mock window.go.main.App
+const createMockApp = () => ({
+  GetAutoSwitchSettings: vi.fn(),
+  SaveAutoSwitchSettings: vi.fn(),
+  StartAutoSwitchMonitor: vi.fn(),
+  StopAutoSwitchMonitor: vi.fn(),
+  GetAutoSwitchStatus: vi.fn(),
+})
+
+let mockApp = createMockApp()
+
+// Setup global mock
+beforeEach(() => {
+  mockApp = createMockApp()
+  vi.stubGlobal('window', {
+    go: {
+      main: {
+        App: mockApp,
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useAutoSwitch', () => {
+  describe('初始狀態', () => {
+    it('應該有正確的初始狀態', () => {
+      const {
+        autoSwitchSettings,
+        autoSwitchStatus,
+        savingAutoSwitch,
+      } = useAutoSwitch()
+
+      expect(autoSwitchSettings.value).toEqual({
+        enabled: false,
+        balanceThreshold: 5,
+        minTargetBalance: 50,
+        folderIds: [],
+        subscriptionTypes: [],
+        refreshIntervals: [],
+        notifyOnSwitch: true,
+        notifyOnLowBalance: true,
+      })
+      expect(autoSwitchStatus.value).toEqual({
+        status: 'stopped',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+      expect(savingAutoSwitch.value).toBe(false)
+    })
+  })
+
+  describe('Property 17: 自動切換設定持久化', () => {
+    it('保存設定後應該調用 SaveAutoSwitchSettings API', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          autoSwitchSettingsArbitrary,
+          async (settings) => {
+            // Arrange
+            mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+
+            const { autoSwitchSettings, saveAutoSwitchSettings } = useAutoSwitch()
+            autoSwitchSettings.value = settings
+
+            // Act
+            await saveAutoSwitchSettings()
+
+            // Assert
+            expect(mockApp.SaveAutoSwitchSettings).toHaveBeenCalledWith(settings)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+
+    it('載入設定後應該更新本地狀態', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          autoSwitchSettingsArbitrary,
+          autoSwitchStatusArbitrary,
+          async (settings, status) => {
+            // Arrange
+            mockApp.GetAutoSwitchSettings.mockResolvedValue(settings)
+            mockApp.GetAutoSwitchStatus.mockResolvedValue(status)
+
+            const { autoSwitchSettings, autoSwitchStatus, loadAutoSwitchSettings } = useAutoSwitch()
+
+            // Act
+            await loadAutoSwitchSettings()
+
+            // Assert
+            expect(autoSwitchSettings.value).toEqual(settings)
+            expect(autoSwitchStatus.value).toEqual(status)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('Property 18: 自動切換狀態一致性', () => {
+    it('啟用自動切換應該調用 StartAutoSwitchMonitor', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+      mockApp.StartAutoSwitchMonitor.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetAutoSwitchStatus.mockResolvedValue({
+        status: 'running',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+
+      const { autoSwitchSettings, toggleAutoSwitch } = useAutoSwitch()
+      autoSwitchSettings.value.enabled = true
+
+      // Act
+      await toggleAutoSwitch()
+
+      // Assert
+      expect(mockApp.StartAutoSwitchMonitor).toHaveBeenCalled()
+    })
+
+    it('停用自動切換應該調用 StopAutoSwitchMonitor', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+      mockApp.StopAutoSwitchMonitor.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetAutoSwitchStatus.mockResolvedValue({
+        status: 'stopped',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+
+      const { autoSwitchSettings, toggleAutoSwitch } = useAutoSwitch()
+      autoSwitchSettings.value.enabled = false
+
+      // Act
+      await toggleAutoSwitch()
+
+      // Assert
+      expect(mockApp.StopAutoSwitchMonitor).toHaveBeenCalled()
+    })
+
+    it('啟動監控失敗時應該回滾 enabled 狀態', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+      mockApp.StartAutoSwitchMonitor.mockResolvedValue({ success: false, message: '啟動失敗' })
+      mockApp.GetAutoSwitchStatus.mockResolvedValue({
+        status: 'stopped',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+
+      const { autoSwitchSettings, toggleAutoSwitch } = useAutoSwitch()
+      autoSwitchSettings.value.enabled = true
+
+      // Act
+      const result = await toggleAutoSwitch()
+
+      // Assert
+      expect(autoSwitchSettings.value.enabled).toBe(false)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('Property 19: 刷新規則列表長度不變量', () => {
+    it('添加規則後列表長度增加 1', () => {
+      fc.assert(
+        fc.property(
+          fc.array(refreshIntervalRuleArbitrary, { minLength: 0, maxLength: 5 }),
+          (initialRules) => {
+            const { autoSwitchSettings, addRefreshRule } = useAutoSwitch()
+            autoSwitchSettings.value.refreshIntervals = [...initialRules]
+
+            const initialLength = autoSwitchSettings.value.refreshIntervals.length
+
+            // Act
+            addRefreshRule()
+
+            // Assert
+            expect(autoSwitchSettings.value.refreshIntervals.length).toBe(initialLength + 1)
+          }
+        ),
+        { numRuns: 30 }
+      )
+    })
+
+    it('移除規則後列表長度減少 1', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { autoSwitchSettings, removeRefreshRule } = useAutoSwitch()
+      autoSwitchSettings.value.refreshIntervals = [
+        { minBalance: 0, maxBalance: 100, interval: 30 },
+        { minBalance: 100, maxBalance: 500, interval: 60 },
+        { minBalance: 500, maxBalance: -1, interval: 120 },
+      ]
+
+      const initialLength = autoSwitchSettings.value.refreshIntervals.length
+
+      // Act
+      await removeRefreshRule(1)
+
+      // Assert
+      expect(autoSwitchSettings.value.refreshIntervals.length).toBe(initialLength - 1)
+    })
+  })
+
+  describe('文件夾篩選方法', () => {
+    it('addAutoSwitchFolder 應該添加文件夾 ID', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { autoSwitchSettings, addAutoSwitchFolder } = useAutoSwitch()
+      autoSwitchSettings.value.folderIds = ['folder-1']
+
+      // Act
+      await addAutoSwitchFolder('folder-2')
+
+      // Assert
+      expect(autoSwitchSettings.value.folderIds).toContain('folder-2')
+      expect(mockApp.SaveAutoSwitchSettings).toHaveBeenCalled()
+    })
+
+    it('addAutoSwitchFolder 不應該添加重複的文件夾 ID', async () => {
+      // Arrange
+      const { autoSwitchSettings, addAutoSwitchFolder } = useAutoSwitch()
+      autoSwitchSettings.value.folderIds = ['folder-1']
+
+      // Act
+      await addAutoSwitchFolder('folder-1')
+
+      // Assert
+      expect(autoSwitchSettings.value.folderIds).toEqual(['folder-1'])
+      expect(mockApp.SaveAutoSwitchSettings).not.toHaveBeenCalled()
+    })
+
+    it('removeAutoSwitchFolder 應該移除文件夾 ID', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { autoSwitchSettings, removeAutoSwitchFolder } = useAutoSwitch()
+      autoSwitchSettings.value.folderIds = ['folder-1', 'folder-2']
+
+      // Act
+      await removeAutoSwitchFolder('folder-1')
+
+      // Assert
+      expect(autoSwitchSettings.value.folderIds).toEqual(['folder-2'])
+      expect(mockApp.SaveAutoSwitchSettings).toHaveBeenCalled()
+    })
+  })
+
+  describe('訂閱類型篩選方法', () => {
+    it('addAutoSwitchSubscription 應該添加訂閱類型', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { autoSwitchSettings, addAutoSwitchSubscription } = useAutoSwitch()
+      autoSwitchSettings.value.subscriptionTypes = ['Free']
+
+      // Act
+      await addAutoSwitchSubscription('Pro')
+
+      // Assert
+      expect(autoSwitchSettings.value.subscriptionTypes).toContain('Pro')
+      expect(mockApp.SaveAutoSwitchSettings).toHaveBeenCalled()
+    })
+
+    it('addAutoSwitchSubscription 不應該添加重複的訂閱類型', async () => {
+      // Arrange
+      const { autoSwitchSettings, addAutoSwitchSubscription } = useAutoSwitch()
+      autoSwitchSettings.value.subscriptionTypes = ['Free']
+
+      // Act
+      await addAutoSwitchSubscription('Free')
+
+      // Assert
+      expect(autoSwitchSettings.value.subscriptionTypes).toEqual(['Free'])
+      expect(mockApp.SaveAutoSwitchSettings).not.toHaveBeenCalled()
+    })
+
+    it('removeAutoSwitchSubscription 應該移除訂閱類型', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+
+      const { autoSwitchSettings, removeAutoSwitchSubscription } = useAutoSwitch()
+      autoSwitchSettings.value.subscriptionTypes = ['Free', 'Pro']
+
+      // Act
+      await removeAutoSwitchSubscription('Free')
+
+      // Assert
+      expect(autoSwitchSettings.value.subscriptionTypes).toEqual(['Pro'])
+      expect(mockApp.SaveAutoSwitchSettings).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleAutoSwitchToggle', () => {
+    it('應該更新 enabled 狀態並調用 toggleAutoSwitch', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+      mockApp.StartAutoSwitchMonitor.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetAutoSwitchStatus.mockResolvedValue({
+        status: 'running',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+
+      const { autoSwitchSettings, handleAutoSwitchToggle } = useAutoSwitch()
+      expect(autoSwitchSettings.value.enabled).toBe(false)
+
+      // Act
+      await handleAutoSwitchToggle(true)
+
+      // Assert
+      expect(autoSwitchSettings.value.enabled).toBe(true)
+      expect(mockApp.StartAutoSwitchMonitor).toHaveBeenCalled()
+    })
+  })
+
+  describe('savingAutoSwitch 狀態', () => {
+    it('保存期間 savingAutoSwitch 應該為 true', async () => {
+      // Arrange
+      let resolveSave: (value: any) => void
+      mockApp.SaveAutoSwitchSettings.mockImplementation(() => {
+        return new Promise(resolve => {
+          resolveSave = resolve
+        })
+      })
+
+      const { savingAutoSwitch, saveAutoSwitchSettings } = useAutoSwitch()
+
+      // Act
+      const savePromise = saveAutoSwitchSettings()
+      
+      // Assert - 保存期間
+      expect(savingAutoSwitch.value).toBe(true)
+
+      // 完成保存
+      resolveSave!({ success: true, message: '' })
+      await savePromise
+
+      // Assert - 保存完成後
+      expect(savingAutoSwitch.value).toBe(false)
+    })
+  })
+
+  describe('P1-FIX: toggleAutoSwitch 並發保護', () => {
+    it('快速連續調用 toggleAutoSwitch 應該只執行一次', async () => {
+      // Arrange
+      let resolveToggle: (value: any) => void
+      let callCount = 0
+      
+      mockApp.SaveAutoSwitchSettings.mockImplementation(() => {
+        callCount++
+        return new Promise(resolve => {
+          resolveToggle = resolve
+        })
+      })
+      mockApp.StartAutoSwitchMonitor.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetAutoSwitchStatus.mockResolvedValue({
+        status: 'running',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+
+      const { autoSwitchSettings, toggleAutoSwitch, isToggling } = useAutoSwitch()
+      autoSwitchSettings.value.enabled = true
+
+      // Act - 快速連續調用
+      const promise1 = toggleAutoSwitch()
+      const promise2 = toggleAutoSwitch()
+      const promise3 = toggleAutoSwitch()
+
+      // Assert - 第一次調用應該正在進行
+      expect(isToggling.value).toBe(true)
+
+      // 完成第一次調用
+      resolveToggle!({ success: true, message: '' })
+      await Promise.all([promise1, promise2, promise3])
+
+      // Assert - 只應該調用一次 SaveAutoSwitchSettings
+      expect(callCount).toBe(1)
+      expect(isToggling.value).toBe(false)
+    })
+
+    it('第一次 toggleAutoSwitch 完成後可以再次調用', async () => {
+      // Arrange
+      mockApp.SaveAutoSwitchSettings.mockResolvedValue({ success: true, message: '' })
+      mockApp.StartAutoSwitchMonitor.mockResolvedValue({ success: true, message: '' })
+      mockApp.StopAutoSwitchMonitor.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetAutoSwitchStatus.mockResolvedValue({
+        status: 'running',
+        lastBalance: 0,
+        cooldownRemaining: 0,
+        switchCount: 0,
+      })
+
+      const { autoSwitchSettings, toggleAutoSwitch, isToggling } = useAutoSwitch()
+
+      // Act - 第一次調用
+      autoSwitchSettings.value.enabled = true
+      await toggleAutoSwitch()
+      expect(isToggling.value).toBe(false)
+
+      // Act - 第二次調用（應該可以執行）
+      mockApp.SaveAutoSwitchSettings.mockClear()
+      autoSwitchSettings.value.enabled = false
+      await toggleAutoSwitch()
+
+      // Assert - 第二次調用應該成功
+      expect(mockApp.SaveAutoSwitchSettings).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/composables/__tests__/useBackupManagement.spec.ts
+++ b/frontend/src/composables/__tests__/useBackupManagement.spec.ts
@@ -1,0 +1,1211 @@
+/**
+ * useBackupManagement Composable 測試
+ * @description Property-Based Testing for backup management composable
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { nextTick } from 'vue'
+import { useBackupManagement } from '../useBackupManagement'
+import {
+  backupItemArbitrary,
+  backupListArbitrary,
+  snapshotNameArbitrary,
+  resultArbitrary,
+} from './arbitraries'
+import type { BackupItem, Result } from '@/types/backup'
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+// Mock Wails API
+const mockGetBackupList = vi.fn<() => Promise<BackupItem[]>>()
+const mockCreateBackup = vi.fn<(name: string) => Promise<Result>>()
+const mockSwitchToBackup = vi.fn<(name: string) => Promise<Result>>()
+const mockDeleteBackup = vi.fn<(name: string) => Promise<Result>>()
+const mockRegenerateMachineID = vi.fn<(name: string) => Promise<Result>>()
+const mockRefreshBackupUsage = vi.fn<(name: string) => Promise<any>>()
+const mockGetCurrentMachineID = vi.fn<() => Promise<string>>()
+const mockGetCurrentEnvironmentName = vi.fn<() => Promise<string>>()
+
+// Setup global window.go mock
+beforeEach(() => {
+  vi.clearAllMocks()
+  
+  // Default mock implementations
+  mockGetBackupList.mockResolvedValue([])
+  mockCreateBackup.mockResolvedValue({ success: true, message: '備份成功' })
+  mockSwitchToBackup.mockResolvedValue({ success: true, message: '切換成功' })
+  mockDeleteBackup.mockResolvedValue({ success: true, message: '刪除成功' })
+  mockRegenerateMachineID.mockResolvedValue({ success: true, message: '重新生成成功' })
+  mockRefreshBackupUsage.mockResolvedValue({ success: true, message: '刷新成功' })
+  mockGetCurrentMachineID.mockResolvedValue('test-machine-id')
+  mockGetCurrentEnvironmentName.mockResolvedValue('test-env')
+  
+  // @ts-ignore - Partial mock for testing
+  globalThis.window = {
+    go: {
+      main: {
+        App: {
+          GetBackupList: mockGetBackupList,
+          CreateBackup: mockCreateBackup,
+          SwitchToBackup: mockSwitchToBackup,
+          DeleteBackup: mockDeleteBackup,
+          RegenerateMachineID: mockRegenerateMachineID,
+          RefreshBackupUsage: mockRefreshBackupUsage,
+          GetCurrentMachineID: mockGetCurrentMachineID,
+          GetCurrentEnvironmentName: mockGetCurrentEnvironmentName,
+        },
+      },
+    },
+  } as any
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+
+// ============================================================================
+// Property 1: 篩選結果正確性
+// ============================================================================
+
+describe('Property 1: filteredBackups 篩選結果正確性', () => {
+  it('應根據訂閱篩選條件正確過濾', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 20 }),
+        fc.constantFrom('FREE', 'PRO', 'PRO+', 'POWER', ''),
+        async (backups, filterValue) => {
+          mockGetBackupList.mockResolvedValue(backups)
+          
+          const { filteredBackups, setFilterSubscription, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          setFilterSubscription(filterValue)
+          await nextTick()
+          
+          if (!filterValue) {
+            // 無篩選時應返回所有備份
+            expect(filteredBackups.value.length).toBe(backups.length)
+          } else {
+            // 有篩選時應只返回匹配的備份
+            const subscriptionMap: Record<string, string> = {
+              'FREE': 'KIRO FREE',
+              'PRO': 'KIRO PRO',
+              'PRO+': 'KIRO PRO+',
+              'POWER': 'KIRO POWER'
+            }
+            const target = subscriptionMap[filterValue]
+            const expected = backups.filter(b => b.subscriptionTitle?.toUpperCase() === target)
+            expect(filteredBackups.value.length).toBe(expected.length)
+          }
+        }
+      ),
+      { numRuns: 50 }
+    )
+  })
+
+  it('應根據提供者篩選條件正確過濾', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 20 }),
+        fc.constantFrom('AWS', 'GitHub', ''),
+        async (backups, filterValue) => {
+          mockGetBackupList.mockResolvedValue(backups)
+          
+          const { filteredBackups, setFilterProvider, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          setFilterProvider(filterValue)
+          await nextTick()
+          
+          if (!filterValue) {
+            expect(filteredBackups.value.length).toBe(backups.length)
+          } else if (filterValue === 'AWS') {
+            // AWS 篩選應包含 AWS 和 BuilderId
+            const expected = backups.filter(b => b.provider === 'AWS' || b.provider === 'BuilderId')
+            expect(filteredBackups.value.length).toBe(expected.length)
+          } else {
+            const expected = backups.filter(b => b.provider === filterValue)
+            expect(filteredBackups.value.length).toBe(expected.length)
+          }
+        }
+      ),
+      { numRuns: 50 }
+    )
+  })
+
+  it('應根據餘額篩選條件正確過濾', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 20 }),
+        fc.constantFrom('LOW', 'NORMAL', 'NO_DATA', ''),
+        async (backups, filterValue) => {
+          mockGetBackupList.mockResolvedValue(backups)
+          
+          const { filteredBackups, setFilterBalance, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          setFilterBalance(filterValue)
+          await nextTick()
+          
+          if (!filterValue) {
+            expect(filteredBackups.value.length).toBe(backups.length)
+          } else if (filterValue === 'LOW') {
+            const expected = backups.filter(b => b.usageLimit > 0 && b.isLowBalance)
+            expect(filteredBackups.value.length).toBe(expected.length)
+          } else if (filterValue === 'NORMAL') {
+            const expected = backups.filter(b => b.usageLimit > 0 && !b.isLowBalance)
+            expect(filteredBackups.value.length).toBe(expected.length)
+          } else if (filterValue === 'NO_DATA') {
+            const expected = backups.filter(b => b.usageLimit === 0)
+            expect(filteredBackups.value.length).toBe(expected.length)
+          }
+        }
+      ),
+      { numRuns: 50 }
+    )
+  })
+
+  it('應根據搜尋關鍵字正確過濾', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 20 }),
+        fc.string({ minLength: 0, maxLength: 10 }),
+        async (backups, searchQuery) => {
+          mockGetBackupList.mockResolvedValue(backups)
+          
+          const { filteredBackups, searchQuery: query, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          query.value = searchQuery
+          await nextTick()
+          
+          if (!searchQuery.trim()) {
+            expect(filteredBackups.value.length).toBe(backups.length)
+          } else {
+            const q = searchQuery.toLowerCase()
+            const expected = backups.filter(b =>
+              b.name.toLowerCase().includes(q) ||
+              b.machineId?.toLowerCase().includes(q) ||
+              b.provider?.toLowerCase().includes(q)
+            )
+            expect(filteredBackups.value.length).toBe(expected.length)
+          }
+        }
+      ),
+      { numRuns: 50 }
+    )
+  })
+})
+
+
+// ============================================================================
+// Property 2: 備份 CRUD 列表長度不變量
+// ============================================================================
+
+describe('Property 2: 備份 CRUD 列表長度不變量', () => {
+  it('創建備份後列表長度應增加 1', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 0, maxLength: 10 }),
+        snapshotNameArbitrary,
+        async (initialBackups, newName) => {
+          // 確保新名稱不與現有名稱重複
+          const existingNames = new Set(initialBackups.map(b => b.name))
+          if (existingNames.has(newName)) return // Skip this case
+          
+          const initialLength = initialBackups.length
+          
+          // Mock: 創建成功後返回包含新備份的列表
+          mockGetBackupList.mockResolvedValueOnce(initialBackups)
+          mockCreateBackup.mockResolvedValue({ success: true, message: '備份成功' })
+          
+          const newBackup: BackupItem = {
+            name: newName,
+            backupTime: new Date().toISOString(),
+            hasToken: true,
+            hasMachineId: true,
+            machineId: 'new-machine-id',
+            provider: 'AWS',
+            isCurrent: false,
+            isOriginalMachine: false,
+            isTokenExpired: false,
+            subscriptionTitle: 'KIRO FREE',
+            usageLimit: 1000,
+            currentUsage: 0,
+            balance: 1000,
+            isLowBalance: false,
+            cachedAt: new Date().toISOString(),
+            folderId: '',
+          }
+          
+          const { backups, createBackup, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          expect(backups.value.length).toBe(initialLength)
+          
+          // 模擬創建後重新載入
+          mockGetBackupList.mockResolvedValueOnce([...initialBackups, newBackup])
+          const result = await createBackup(newName)
+          
+          if (result.success) {
+            await loadBackups()
+            expect(backups.value.length).toBe(initialLength + 1)
+          }
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+
+  it('刪除備份後列表長度應減少 1', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10 }),
+        async (initialBackups) => {
+          const initialLength = initialBackups.length
+          const backupToDelete = initialBackups[0]
+          
+          mockGetBackupList.mockResolvedValueOnce(initialBackups)
+          mockDeleteBackup.mockResolvedValue({ success: true, message: '刪除成功' })
+          
+          const { backups, deleteBackup, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          expect(backups.value.length).toBe(initialLength)
+          
+          // 模擬刪除後重新載入
+          mockGetBackupList.mockResolvedValueOnce(initialBackups.slice(1))
+          const result = await deleteBackup(backupToDelete.name)
+          
+          if (result.success) {
+            await loadBackups()
+            expect(backups.value.length).toBe(initialLength - 1)
+          }
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+
+// ============================================================================
+// Property 3: 重複名稱創建失敗
+// ============================================================================
+
+describe('Property 3: 重複名稱創建失敗', () => {
+  it('創建重複名稱的備份應失敗', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10 }),
+        async (initialBackups) => {
+          const existingName = initialBackups[0].name
+          
+          mockGetBackupList.mockResolvedValue(initialBackups)
+          mockCreateBackup.mockResolvedValue({ success: false, message: '備份名稱已存在' })
+          
+          const { createBackup, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          const result = await createBackup(existingName)
+          
+          expect(result.success).toBe(false)
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+// ============================================================================
+// Property 4: 備份切換狀態一致性
+// ============================================================================
+
+describe('Property 4: 備份切換狀態一致性', () => {
+  it('切換後只有一個 isCurrent=true', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 2, maxLength: 10, withCurrentItem: true }),
+        fc.nat(),
+        async (initialBackups, targetIndex) => {
+          const safeIndex = targetIndex % initialBackups.length
+          const targetBackup = initialBackups[safeIndex]
+          
+          mockGetBackupList.mockResolvedValueOnce(initialBackups)
+          mockSwitchToBackup.mockResolvedValue({ success: true, message: '切換成功' })
+          
+          const { backups, switchToBackup, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          // 模擬切換後的狀態
+          const updatedBackups = initialBackups.map(b => ({
+            ...b,
+            isCurrent: b.name === targetBackup.name,
+          }))
+          mockGetBackupList.mockResolvedValueOnce(updatedBackups)
+          
+          const result = await switchToBackup(targetBackup.name)
+          
+          if (result.success) {
+            await loadBackups()
+            
+            // 驗證只有一個 isCurrent=true
+            const currentCount = backups.value.filter(b => b.isCurrent).length
+            expect(currentCount).toBe(1)
+            
+            // 驗證是正確的備份
+            const currentBackup = backups.value.find(b => b.isCurrent)
+            expect(currentBackup?.name).toBe(targetBackup.name)
+          }
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+
+// ============================================================================
+// Property 5: 批量刷新冷卻期過濾
+// ============================================================================
+
+describe('Property 5: 批量刷新冷卻期過濾', () => {
+  it('批量刷新應跳過冷卻期中的備份', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 2, max: 10 }),
+        async (count) => {
+          // 生成唯一名稱的備份列表
+          const initialBackups: BackupItem[] = Array.from({ length: count }, (_, i) => ({
+            name: `backup-${i}`,
+            backupTime: new Date().toISOString(),
+            hasToken: true,
+            hasMachineId: true,
+            machineId: `machine-${i}`,
+            provider: 'AWS',
+            isCurrent: i === 0,
+            isOriginalMachine: false,
+            isTokenExpired: false,
+            subscriptionTitle: 'KIRO FREE',
+            usageLimit: 1000,
+            currentUsage: 0,
+            balance: 1000,
+            isLowBalance: false,
+            cachedAt: new Date().toISOString(),
+            folderId: '',
+          }))
+          
+          mockGetBackupList.mockResolvedValue(initialBackups)
+          mockRefreshBackupUsage.mockClear()
+          
+          const { 
+            selectedBackups, 
+            toggleSelect, 
+            batchRefreshUsage, 
+            loadBackups 
+          } = useBackupManagement()
+          
+          await loadBackups()
+          
+          // 選擇所有備份
+          initialBackups.forEach(b => toggleSelect(b.name))
+          
+          // 模擬冷卻期函數：假設第一個備份在冷卻期中
+          const cooldownSet = new Set([initialBackups[0].name])
+          const isInCooldown = (name: string) => cooldownSet.has(name)
+          
+          // 執行批量刷新
+          await batchRefreshUsage(isInCooldown)
+          
+          // 驗證：冷卻期中的備份不應被刷新
+          const refreshCalls = mockRefreshBackupUsage.mock.calls
+          const refreshedNames = refreshCalls.map(call => call[0])
+          
+          expect(refreshedNames).not.toContain(initialBackups[0].name)
+          
+          // 其他備份應該被刷新
+          const expectedRefreshed = initialBackups.slice(1).map(b => b.name)
+          expectedRefreshed.forEach(name => {
+            expect(refreshedNames).toContain(name)
+          })
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+// ============================================================================
+// Property 6: 批量重新生成機器碼
+// ============================================================================
+
+describe('Property 6: 批量重新生成機器碼', () => {
+  it('批量操作應正確執行', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 10 }),
+        async (count) => {
+          // 生成唯一名稱的備份列表
+          const initialBackups: BackupItem[] = Array.from({ length: count }, (_, i) => ({
+            name: `backup-${i}`,
+            backupTime: new Date().toISOString(),
+            hasToken: true,
+            hasMachineId: true,
+            machineId: `machine-${i}`,
+            provider: 'AWS',
+            isCurrent: i === 0,
+            isOriginalMachine: false,
+            isTokenExpired: false,
+            subscriptionTitle: 'KIRO FREE',
+            usageLimit: 1000,
+            currentUsage: 0,
+            balance: 1000,
+            isLowBalance: false,
+            cachedAt: new Date().toISOString(),
+            folderId: '',
+          }))
+          
+          mockGetBackupList.mockResolvedValue(initialBackups)
+          mockRegenerateMachineID.mockClear()
+          
+          const { 
+            selectedBackups, 
+            toggleSelect, 
+            batchRegenerateMachineID, 
+            loadBackups 
+          } = useBackupManagement()
+          
+          await loadBackups()
+          
+          // 選擇所有備份
+          initialBackups.forEach(b => toggleSelect(b.name))
+          
+          const selectedCount = selectedBackups.value.size
+          expect(selectedCount).toBe(initialBackups.length)
+          
+          // 執行批量重新生成
+          await batchRegenerateMachineID()
+          
+          // 驗證：每個選中的備份都應該被調用
+          expect(mockRegenerateMachineID).toHaveBeenCalledTimes(initialBackups.length)
+          
+          // 驗證：操作完成後選擇應被清空
+          expect(selectedBackups.value.size).toBe(0)
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+
+// ============================================================================
+// Property 31: 並發 loadBackups 競態條件防護
+// ============================================================================
+
+describe('Property 31: 並發 loadBackups 競態條件防護', () => {
+  it('多次並發調用應只執行一次', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10 }),
+        fc.integer({ min: 2, max: 5 }),
+        async (initialBackups, concurrentCalls) => {
+          // 使用延遲的 mock 來模擬異步操作
+          let callCount = 0
+          mockGetBackupList.mockImplementation(async () => {
+            callCount++
+            // 模擬網絡延遲
+            await new Promise(resolve => setTimeout(resolve, 10))
+            return initialBackups
+          })
+          
+          const { loadBackups, isLoadingBackups } = useBackupManagement()
+          
+          // 同時發起多個 loadBackups 調用
+          const promises = Array(concurrentCalls).fill(null).map(() => loadBackups())
+          
+          // 等待所有調用完成
+          await Promise.all(promises)
+          
+          // 驗證：API 只應被調用一次（競態條件防護）
+          expect(callCount).toBe(1)
+          
+          // 驗證：loading 狀態應該恢復為 false
+          expect(isLoadingBackups.value).toBe(false)
+        }
+      ),
+      { numRuns: 20 }
+    )
+  })
+
+  it('第一次調用完成後可以再次調用', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10 }),
+        async (initialBackups) => {
+          let callCount = 0
+          mockGetBackupList.mockImplementation(async () => {
+            callCount++
+            await new Promise(resolve => setTimeout(resolve, 5))
+            return initialBackups
+          })
+          
+          const { loadBackups, isLoadingBackups } = useBackupManagement()
+          
+          // 第一次調用
+          await loadBackups()
+          expect(callCount).toBe(1)
+          expect(isLoadingBackups.value).toBe(false)
+          
+          // 第二次調用（應該可以執行）
+          await loadBackups()
+          expect(callCount).toBe(2)
+          expect(isLoadingBackups.value).toBe(false)
+        }
+      ),
+      { numRuns: 20 }
+    )
+  })
+})
+
+// ============================================================================
+// 額外測試：activeBackup 計算屬性
+// ============================================================================
+
+describe('activeBackup 計算屬性', () => {
+  it('應返回 isCurrent=true 的備份', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10, withCurrentItem: true }),
+        async (initialBackups) => {
+          mockGetBackupList.mockResolvedValue(initialBackups)
+          
+          const { activeBackup, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          const currentBackup = initialBackups.find(b => b.isCurrent)
+          
+          if (currentBackup) {
+            expect(activeBackup.value).not.toBeNull()
+            expect(activeBackup.value?.name).toBe(currentBackup.name)
+          }
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+
+  it('無 isCurrent=true 時應返回 null', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10, withCurrentItem: false }),
+        async (initialBackups) => {
+          // 確保沒有 isCurrent=true
+          const backupsWithoutCurrent = initialBackups.map(b => ({ ...b, isCurrent: false }))
+          mockGetBackupList.mockResolvedValue(backupsWithoutCurrent)
+          
+          const { activeBackup, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          expect(activeBackup.value).toBeNull()
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+// ============================================================================
+// 額外測試：選擇操作
+// ============================================================================
+
+describe('選擇操作', () => {
+  it('toggleSelect 應正確切換選擇狀態', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        backupListArbitrary({ minLength: 1, maxLength: 10 }),
+        async (initialBackups) => {
+          mockGetBackupList.mockResolvedValue(initialBackups)
+          
+          const { selectedBackups, toggleSelect, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          const targetName = initialBackups[0].name
+          
+          // 初始狀態：未選中
+          expect(selectedBackups.value.has(targetName)).toBe(false)
+          
+          // 第一次切換：選中
+          toggleSelect(targetName)
+          expect(selectedBackups.value.has(targetName)).toBe(true)
+          
+          // 第二次切換：取消選中
+          toggleSelect(targetName)
+          expect(selectedBackups.value.has(targetName)).toBe(false)
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+
+  it('toggleSelectAll 應正確全選/取消全選', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 10 }),
+        async (count) => {
+          // 生成唯一名稱的備份列表
+          const initialBackups: BackupItem[] = Array.from({ length: count }, (_, i) => ({
+            name: `backup-${i}`,
+            backupTime: new Date().toISOString(),
+            hasToken: true,
+            hasMachineId: true,
+            machineId: `machine-${i}`,
+            provider: 'AWS',
+            isCurrent: i === 0,
+            isOriginalMachine: false,
+            isTokenExpired: false,
+            subscriptionTitle: 'KIRO FREE',
+            usageLimit: 1000,
+            currentUsage: 0,
+            balance: 1000,
+            isLowBalance: false,
+            cachedAt: new Date().toISOString(),
+            folderId: '',
+          }))
+          
+          mockGetBackupList.mockResolvedValue(initialBackups)
+          
+          const { selectedBackups, toggleSelectAll, filteredBackups, loadBackups } = useBackupManagement()
+          await loadBackups()
+          
+          // 初始狀態：無選中
+          expect(selectedBackups.value.size).toBe(0)
+          
+          // 全選
+          toggleSelectAll()
+          expect(selectedBackups.value.size).toBe(filteredBackups.value.length)
+          
+          // 取消全選
+          toggleSelectAll()
+          expect(selectedBackups.value.size).toBe(0)
+        }
+      ),
+      { numRuns: 30 }
+    )
+  })
+})
+
+// ============================================================================
+// P0-FIX: 批量操作錯誤回報
+// ============================================================================
+
+describe('P0-FIX: 批量操作錯誤回報', () => {
+  it('batchDelete 應返回 BatchResult 包含成功和失敗項目', async () => {
+    // 生成 5 個備份
+    const initialBackups: BackupItem[] = Array.from({ length: 5 }, (_, i) => ({
+      name: `backup-${i}`,
+      backupTime: new Date().toISOString(),
+      hasToken: true,
+      hasMachineId: true,
+      machineId: `machine-${i}`,
+      provider: 'AWS',
+      isCurrent: false,
+      isOriginalMachine: false,
+      isTokenExpired: false,
+      subscriptionTitle: 'KIRO FREE',
+      usageLimit: 1000,
+      currentUsage: 0,
+      balance: 1000,
+      isLowBalance: false,
+      cachedAt: new Date().toISOString(),
+      folderId: '',
+    }))
+    
+    mockGetBackupList.mockResolvedValue(initialBackups)
+    
+    // 模擬第 3 個備份刪除失敗
+    mockDeleteBackup.mockImplementation(async (name: string) => {
+      if (name === 'backup-2') {
+        throw new Error('刪除失敗')
+      }
+      return { success: true, message: '刪除成功' }
+    })
+    
+    const { selectedBackups, toggleSelect, batchDelete, loadBackups } = useBackupManagement()
+    await loadBackups()
+    
+    // 選擇所有備份
+    initialBackups.forEach(b => toggleSelect(b.name))
+    
+    // 執行批量刪除
+    const result = await batchDelete()
+    
+    // 驗證返回 BatchResult
+    expect(result).toBeDefined()
+    expect(result.successCount).toBe(4)
+    expect(result.failedItems).toHaveLength(1)
+    expect(result.failedItems[0].name).toBe('backup-2')
+    expect(result.failedItems[0].error).toBe('刪除失敗')
+  })
+
+  it('batchRegenerateMachineID 應返回 BatchResult', async () => {
+    const initialBackups: BackupItem[] = Array.from({ length: 3 }, (_, i) => ({
+      name: `backup-${i}`,
+      backupTime: new Date().toISOString(),
+      hasToken: true,
+      hasMachineId: true,
+      machineId: `machine-${i}`,
+      provider: 'AWS',
+      isCurrent: false,
+      isOriginalMachine: false,
+      isTokenExpired: false,
+      subscriptionTitle: 'KIRO FREE',
+      usageLimit: 1000,
+      currentUsage: 0,
+      balance: 1000,
+      isLowBalance: false,
+      cachedAt: new Date().toISOString(),
+      folderId: '',
+    }))
+    
+    mockGetBackupList.mockResolvedValue(initialBackups)
+    mockRegenerateMachineID.mockResolvedValue({ success: true, message: '' })
+    
+    const { selectedBackups, toggleSelect, batchRegenerateMachineID, loadBackups } = useBackupManagement()
+    await loadBackups()
+    
+    initialBackups.forEach(b => toggleSelect(b.name))
+    
+    const result = await batchRegenerateMachineID()
+    
+    expect(result).toBeDefined()
+    expect(result.success).toBe(true)
+    expect(result.successCount).toBe(3)
+    expect(result.failedItems).toHaveLength(0)
+  })
+
+  it('batchRefreshUsage 應返回 BatchResult 包含跳過的冷卻期項目', async () => {
+    const initialBackups: BackupItem[] = Array.from({ length: 5 }, (_, i) => ({
+      name: `backup-${i}`,
+      backupTime: new Date().toISOString(),
+      hasToken: true,
+      hasMachineId: true,
+      machineId: `machine-${i}`,
+      provider: 'AWS',
+      isCurrent: false,
+      isOriginalMachine: false,
+      isTokenExpired: false,
+      subscriptionTitle: 'KIRO FREE',
+      usageLimit: 1000,
+      currentUsage: 0,
+      balance: 1000,
+      isLowBalance: false,
+      cachedAt: new Date().toISOString(),
+      folderId: '',
+    }))
+    
+    mockGetBackupList.mockResolvedValue(initialBackups)
+    mockRefreshBackupUsage.mockResolvedValue({ success: true, message: '' })
+    
+    const { selectedBackups, toggleSelect, batchRefreshUsage, loadBackups } = useBackupManagement()
+    await loadBackups()
+    
+    initialBackups.forEach(b => toggleSelect(b.name))
+    
+    // 模擬 2 個備份在冷卻期
+    const cooldownSet = new Set(['backup-0', 'backup-2'])
+    const isInCooldown = (name: string) => cooldownSet.has(name)
+    
+    const result = await batchRefreshUsage(isInCooldown)
+    
+    expect(result).toBeDefined()
+    expect(result.successCount).toBe(3) // 5 - 2 = 3
+    expect(result.skippedCount).toBe(2) // 冷卻期中的 2 個
+  })
+})
+
+
+// ============================================================================
+// Phase 2 Task 1: 擴展功能測試
+// ============================================================================
+
+describe('Phase 2 Task 1.1: useBackupManagement 擴展功能', () => {
+  describe('regenerateMachineID 單一備份重新生成機器碼', () => {
+    it('應成功重新生成指定備份的機器碼', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          snapshotNameArbitrary,
+          async (backupName) => {
+            mockRegenerateMachineID.mockResolvedValue({ success: true, message: '重新生成成功' })
+            
+            const { regenerateMachineID, regeneratingId } = useBackupManagement()
+            
+            // 驗證初始狀態
+            expect(regeneratingId.value).toBe(null)
+            
+            const result = await regenerateMachineID(backupName)
+            
+            // 驗證 API 被正確調用
+            expect(mockRegenerateMachineID).toHaveBeenCalledWith(backupName)
+            expect(result.success).toBe(true)
+            
+            // 驗證狀態恢復
+            expect(regeneratingId.value).toBe(null)
+          }
+        ),
+        { numRuns: 30 }
+      )
+    })
+
+    it('重新生成失敗時應返回錯誤結果', async () => {
+      mockRegenerateMachineID.mockRejectedValue(new Error('重新生成失敗'))
+      
+      const { regenerateMachineID } = useBackupManagement()
+      
+      const result = await regenerateMachineID('test-backup')
+      
+      expect(result.success).toBe(false)
+      expect(result.message).toBe('重新生成失敗')
+    })
+
+    it('重新生成過程中 regeneratingId 應設為備份名稱', async () => {
+      let resolvePromise: (value: Result) => void
+      const pendingPromise = new Promise<Result>((resolve) => {
+        resolvePromise = resolve
+      })
+      mockRegenerateMachineID.mockReturnValue(pendingPromise)
+      
+      const { regenerateMachineID, regeneratingId } = useBackupManagement()
+      
+      const promise = regenerateMachineID('test-backup')
+      
+      // 驗證進行中狀態
+      expect(regeneratingId.value).toBe('test-backup')
+      
+      // 完成操作
+      resolvePromise!({ success: true, message: '' })
+      await promise
+      
+      // 驗證狀態恢復
+      expect(regeneratingId.value).toBe(null)
+    })
+  })
+
+  describe('loadFullBackupData 整合載入', () => {
+    it('應整合載入備份列表、設定和狀態', async () => {
+      const mockBackups: BackupItem[] = [
+        {
+          name: 'backup-1',
+          backupTime: new Date().toISOString(),
+          hasToken: true,
+          hasMachineId: true,
+          machineId: 'machine-1',
+          provider: 'AWS',
+          isCurrent: true,
+          isOriginalMachine: false,
+          isTokenExpired: false,
+          subscriptionTitle: 'KIRO FREE',
+          usageLimit: 1000,
+          currentUsage: 0,
+          balance: 1000,
+          isLowBalance: false,
+          cachedAt: new Date().toISOString(),
+          folderId: '',
+        }
+      ]
+      
+      mockGetBackupList.mockResolvedValue(mockBackups)
+      mockGetCurrentMachineID.mockResolvedValue('current-machine-id')
+      mockGetCurrentEnvironmentName.mockResolvedValue('current-env')
+      
+      const { loadFullBackupData, backups, currentMachineId, currentEnvironmentName } = useBackupManagement()
+      
+      await loadFullBackupData()
+      
+      // 驗證所有數據都被載入
+      expect(backups.value).toEqual(mockBackups)
+      expect(currentMachineId.value).toBe('current-machine-id')
+      expect(currentEnvironmentName.value).toBe('current-env')
+    })
+
+    it('loadFullBackupData 應支援 onComplete 回調', async () => {
+      const mockBackups: BackupItem[] = []
+      mockGetBackupList.mockResolvedValue(mockBackups)
+      mockGetCurrentMachineID.mockResolvedValue('machine-id')
+      mockGetCurrentEnvironmentName.mockResolvedValue('env-name')
+      
+      const { loadFullBackupData } = useBackupManagement()
+      
+      const onComplete = vi.fn()
+      await loadFullBackupData({ onComplete })
+      
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+
+    it('loadFullBackupData 失敗時應調用 onError 回調', async () => {
+      mockGetBackupList.mockRejectedValue(new Error('載入失敗'))
+      
+      const { loadFullBackupData } = useBackupManagement()
+      
+      const onError = vi.fn()
+      await loadFullBackupData({ onError })
+      
+      expect(onError).toHaveBeenCalledWith(expect.any(Error))
+    })
+  })
+})
+
+
+// ============================================================================
+// Task 1.1: deleteBackup 超時保護測試
+// ============================================================================
+
+describe('Task 1.1: deleteBackup 超時保護', () => {
+  it('deleteBackup 應該使用 withTimeout 包裝 API 調用', async () => {
+    // Arrange: 模擬 API 超時（30秒以上）
+    vi.useFakeTimers()
+    
+    let resolveDelete: (value: Result) => void
+    mockDeleteBackup.mockImplementation(() => {
+      return new Promise(resolve => {
+        resolveDelete = resolve
+      })
+    })
+    
+    const { deleteBackup, deletingBackup } = useBackupManagement()
+    
+    // Act: 開始刪除操作
+    const deletePromise = deleteBackup('test-backup')
+    
+    // 驗證 deletingBackup 狀態為 true
+    expect(deletingBackup.value).toBe('test-backup')
+    
+    // 快進 30 秒（超時時間）
+    await vi.advanceTimersByTimeAsync(30000)
+    
+    // 等待 Promise 完成
+    const result = await deletePromise
+    
+    // Assert: 應該返回超時錯誤
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('超時')
+    
+    // 驗證 deletingBackup 狀態已重置
+    expect(deletingBackup.value).toBe(null)
+    
+    vi.useRealTimers()
+  })
+
+  it('deleteBackup 成功時應該正常返回結果', async () => {
+    // Arrange
+    mockDeleteBackup.mockResolvedValue({ success: true, message: '刪除成功' })
+    
+    const { deleteBackup, deletingBackup } = useBackupManagement()
+    
+    // Act
+    const result = await deleteBackup('test-backup')
+    
+    // Assert
+    expect(result.success).toBe(true)
+    expect(deletingBackup.value).toBe(null)
+  })
+
+  it('deleteBackup 超時後 finally 區塊應該重置 deletingBackup 狀態', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    
+    mockDeleteBackup.mockImplementation(() => {
+      return new Promise(() => {
+        // 永不 resolve，模擬超時
+      })
+    })
+    
+    const { deleteBackup, deletingBackup } = useBackupManagement()
+    
+    // Act
+    const deletePromise = deleteBackup('test-backup')
+    expect(deletingBackup.value).toBe('test-backup')
+    
+    // 快進超過超時時間
+    await vi.advanceTimersByTimeAsync(31000)
+    
+    await deletePromise
+    
+    // Assert: 狀態應該被重置
+    expect(deletingBackup.value).toBe(null)
+    
+    vi.useRealTimers()
+  })
+})
+
+// ============================================================================
+// Task 1.2: regenerateMachineID 超時保護測試
+// ============================================================================
+
+describe('Task 1.2: regenerateMachineID 超時保護', () => {
+  it('regenerateMachineID 應該使用 withTimeout 包裝 API 調用', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    
+    mockRegenerateMachineID.mockImplementation(() => {
+      return new Promise(() => {
+        // 永不 resolve，模擬超時
+      })
+    })
+    
+    const { regenerateMachineID, regeneratingId } = useBackupManagement()
+    
+    // Act
+    const regeneratePromise = regenerateMachineID('test-backup')
+    
+    expect(regeneratingId.value).toBe('test-backup')
+    
+    // 快進 30 秒
+    await vi.advanceTimersByTimeAsync(30000)
+    
+    const result = await regeneratePromise
+    
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('超時')
+    expect(regeneratingId.value).toBe(null)
+    
+    vi.useRealTimers()
+  })
+
+  it('regenerateMachineID 成功時應該正常返回結果', async () => {
+    // Arrange
+    mockRegenerateMachineID.mockResolvedValue({ success: true, message: '重新生成成功' })
+    
+    const { regenerateMachineID, regeneratingId } = useBackupManagement()
+    
+    // Act
+    const result = await regenerateMachineID('test-backup')
+    
+    // Assert
+    expect(result.success).toBe(true)
+    expect(regeneratingId.value).toBe(null)
+  })
+
+  it('regenerateMachineID 超時後 finally 區塊應該重置 regeneratingId 狀態', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    
+    mockRegenerateMachineID.mockImplementation(() => {
+      return new Promise(() => {})
+    })
+    
+    const { regenerateMachineID, regeneratingId } = useBackupManagement()
+    
+    // Act
+    const promise = regenerateMachineID('test-backup')
+    expect(regeneratingId.value).toBe('test-backup')
+    
+    await vi.advanceTimersByTimeAsync(31000)
+    await promise
+    
+    // Assert
+    expect(regeneratingId.value).toBe(null)
+    
+    vi.useRealTimers()
+  })
+})
+
+// ============================================================================
+// Task 1.5: 批量刷新冷卻期檢查測試
+// ============================================================================
+
+describe('Task 1.5: 批量刷新全部冷卻期檢查', () => {
+  it('當所有選中項目都在冷卻期時，應該返回 allInCooldown 標記', async () => {
+    // Arrange
+    const initialBackups: BackupItem[] = Array.from({ length: 3 }, (_, i) => ({
+      name: `backup-${i}`,
+      backupTime: new Date().toISOString(),
+      hasToken: true,
+      hasMachineId: true,
+      machineId: `machine-${i}`,
+      provider: 'AWS',
+      isCurrent: false,
+      isOriginalMachine: false,
+      isTokenExpired: false,
+      subscriptionTitle: 'KIRO FREE',
+      usageLimit: 1000,
+      currentUsage: 0,
+      balance: 1000,
+      isLowBalance: false,
+      cachedAt: new Date().toISOString(),
+      folderId: '',
+    }))
+    
+    mockGetBackupList.mockResolvedValue(initialBackups)
+    
+    const { selectedBackups, toggleSelect, batchRefreshUsage, loadBackups } = useBackupManagement()
+    await loadBackups()
+    
+    // 選擇所有備份
+    initialBackups.forEach(b => toggleSelect(b.name))
+    
+    // 所有備份都在冷卻期
+    const isInCooldown = () => true
+    
+    // Act
+    const result = await batchRefreshUsage(isInCooldown)
+    
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.successCount).toBe(0)
+    expect(result.skippedCount).toBe(3)
+    expect(result.allInCooldown).toBe(true)
+    
+    // 選擇狀態不應該被清空
+    expect(selectedBackups.value.size).toBe(3)
+  })
+
+  it('當部分項目在冷卻期時，應該正常處理非冷卻期項目', async () => {
+    // Arrange
+    const initialBackups: BackupItem[] = Array.from({ length: 3 }, (_, i) => ({
+      name: `backup-${i}`,
+      backupTime: new Date().toISOString(),
+      hasToken: true,
+      hasMachineId: true,
+      machineId: `machine-${i}`,
+      provider: 'AWS',
+      isCurrent: false,
+      isOriginalMachine: false,
+      isTokenExpired: false,
+      subscriptionTitle: 'KIRO FREE',
+      usageLimit: 1000,
+      currentUsage: 0,
+      balance: 1000,
+      isLowBalance: false,
+      cachedAt: new Date().toISOString(),
+      folderId: '',
+    }))
+    
+    mockGetBackupList.mockResolvedValue(initialBackups)
+    mockRefreshBackupUsage.mockResolvedValue({ success: true })
+    
+    const { selectedBackups, toggleSelect, batchRefreshUsage, loadBackups } = useBackupManagement()
+    await loadBackups()
+    
+    initialBackups.forEach(b => toggleSelect(b.name))
+    
+    // 只有第一個在冷卻期
+    const cooldownSet = new Set(['backup-0'])
+    const isInCooldown = (name: string) => cooldownSet.has(name)
+    
+    // Act
+    const result = await batchRefreshUsage(isInCooldown)
+    
+    // Assert
+    expect(result.allInCooldown).toBeUndefined() // 不是全部在冷卻期
+    expect(result.successCount).toBe(2)
+    expect(result.skippedCount).toBe(1)
+    
+    // 選擇狀態應該被清空（因為有成功處理的項目）
+    expect(selectedBackups.value.size).toBe(0)
+  })
+})

--- a/frontend/src/composables/__tests__/useFolderManagement.spec.ts
+++ b/frontend/src/composables/__tests__/useFolderManagement.spec.ts
@@ -1,0 +1,564 @@
+/**
+ * useFolderManagement Composable 測試
+ * @description Property-Based Testing for 文件夾管理功能
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useFolderManagement } from '../useFolderManagement'
+import {
+  folderItemArbitrary,
+  folderListArbitrary,
+  backupItemArbitrary,
+  backupListArbitrary,
+} from './arbitraries'
+import type { FolderItem, BackupItem, Result } from '@/types/backup'
+
+// Mock window.go.main.App
+const createMockApp = () => ({
+  GetFolderList: vi.fn(),
+  CreateFolder: vi.fn(),
+  RenameFolder: vi.fn(),
+  DeleteFolder: vi.fn(),
+  AssignSnapshotToFolder: vi.fn(),
+  UnassignSnapshot: vi.fn(),
+})
+
+let mockApp = createMockApp()
+
+// Setup global mock
+beforeEach(() => {
+  // 每次測試前重新創建 mock，確保調用次數重置
+  mockApp = createMockApp()
+  vi.stubGlobal('window', {
+    go: {
+      main: {
+        App: mockApp,
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useFolderManagement', () => {
+  describe('初始狀態', () => {
+    it('應該有正確的初始狀態', () => {
+      const {
+        folders,
+        expandedFolders,
+        uncategorizedExpanded,
+        showCreateFolderModal,
+        newFolderName,
+        creatingFolder,
+        renamingFolder,
+        renameFolderName,
+        deletingFolder,
+        dragOverFolderId,
+        dragOverUncategorized,
+        showDeleteFolderDialog,
+        folderToDelete,
+      } = useFolderManagement()
+
+      expect(folders.value).toEqual([])
+      expect(expandedFolders.value).toEqual(new Set())
+      expect(uncategorizedExpanded.value).toBe(true)
+      expect(showCreateFolderModal.value).toBe(false)
+      expect(newFolderName.value).toBe('')
+      expect(creatingFolder.value).toBe(false)
+      expect(renamingFolder.value).toBeNull()
+      expect(renameFolderName.value).toBe('')
+      expect(deletingFolder.value).toBeNull()
+      expect(dragOverFolderId.value).toBeNull()
+      expect(dragOverUncategorized.value).toBe(false)
+      expect(showDeleteFolderDialog.value).toBe(false)
+      expect(folderToDelete.value).toBeNull()
+    })
+  })
+
+  describe('Property 7: 文件夾 CRUD 列表長度不變量', () => {
+    it('創建文件夾後列表長度增加 1', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          folderListArbitrary({ minLength: 0, maxLength: 5 }),
+          fc.stringMatching(/^[a-zA-Z0-9_-]{1,20}$/),
+          async (initialFolders, newName) => {
+            // Arrange
+            mockApp.GetFolderList.mockResolvedValue(initialFolders)
+            mockApp.CreateFolder.mockImplementation(async (name: string) => {
+              const newFolder: FolderItem = {
+                id: `folder-${Date.now()}`,
+                name,
+                createdAt: new Date().toISOString(),
+                order: initialFolders.length,
+                snapshotCount: 0,
+              }
+              initialFolders.push(newFolder)
+              return { success: true, message: '' }
+            })
+
+            const { folders, loadFolders, createFolder, newFolderName, showCreateFolderModal } = useFolderManagement()
+
+            // Act
+            await loadFolders()
+            const initialLength = folders.value.length
+
+            newFolderName.value = newName
+            showCreateFolderModal.value = true
+            await createFolder()
+            await loadFolders()
+
+            // Assert
+            expect(folders.value.length).toBe(initialLength + 1)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+
+    it('刪除空文件夾後列表長度減少 1', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          folderListArbitrary({ minLength: 1, maxLength: 5 }),
+          async (initialFolders) => {
+            // Arrange
+            const foldersCopy = [...initialFolders]
+            mockApp.GetFolderList.mockResolvedValue(foldersCopy)
+            mockApp.DeleteFolder.mockImplementation(async (id: string) => {
+              const index = foldersCopy.findIndex(f => f.id === id)
+              if (index !== -1) {
+                foldersCopy.splice(index, 1)
+              }
+              return { success: true, message: '' }
+            })
+
+            const { folders, loadFolders, deleteFolder } = useFolderManagement()
+
+            // Act
+            await loadFolders()
+            const initialLength = folders.value.length
+            const folderToDelete = folders.value[0]
+
+            // 模擬空文件夾（getBackupsInFolder 返回空陣列）
+            await deleteFolder(folderToDelete, [])
+            await loadFolders()
+
+            // Assert
+            expect(folders.value.length).toBe(initialLength - 1)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('Property 8: 非法文件夾名稱驗證', () => {
+    it('空名稱應該創建失敗', async () => {
+      const { createFolder, newFolderName, showCreateFolderModal } = useFolderManagement()
+
+      newFolderName.value = ''
+      showCreateFolderModal.value = true
+      await createFolder()
+
+      expect(mockApp.CreateFolder).not.toHaveBeenCalled()
+    })
+
+    it('只有空白的名稱應該創建失敗', async () => {
+      const whitespaceStrings = ['   ', '\t', '\n', '  \t  ', '\n\n']
+      
+      for (const whitespaceOnly of whitespaceStrings) {
+        // 重置 mock
+        mockApp.CreateFolder.mockClear()
+        
+        const { createFolder, newFolderName, showCreateFolderModal } = useFolderManagement()
+
+        newFolderName.value = whitespaceOnly
+        showCreateFolderModal.value = true
+        await createFolder()
+
+        expect(mockApp.CreateFolder).not.toHaveBeenCalled()
+      }
+    })
+  })
+
+  describe('Property 9: 文件夾重命名一致性', () => {
+    it('重命名後文件夾名稱應該更新', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          folderItemArbitrary,
+          fc.stringMatching(/^[a-zA-Z0-9_-]{1,20}$/),
+          async (folder, newName) => {
+            // Arrange
+            const foldersCopy = [{ ...folder }]
+            mockApp.GetFolderList.mockResolvedValue(foldersCopy)
+            mockApp.RenameFolder.mockImplementation(async (id: string, name: string) => {
+              const f = foldersCopy.find(f => f.id === id)
+              if (f) f.name = name
+              return { success: true, message: '' }
+            })
+
+            const {
+              folders,
+              loadFolders,
+              startRenameFolder,
+              confirmRenameFolder,
+              renameFolderName,
+            } = useFolderManagement()
+
+            // Act
+            await loadFolders()
+            startRenameFolder(folder)
+            renameFolderName.value = newName
+            await confirmRenameFolder()
+            await loadFolders()
+
+            // Assert
+            expect(folders.value[0].name).toBe(newName)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('Property 10: 當前備份文件夾保護', () => {
+    it('包含當前使用中備份的文件夾不能刪除', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          folderItemArbitrary,
+          backupItemArbitrary,
+          async (folder, backup) => {
+            // Arrange: 備份在文件夾中且是當前使用中
+            const backupInFolder: BackupItem = {
+              ...backup,
+              folderId: folder.id,
+              isCurrent: true,
+            }
+
+            const { deleteFolder, showDeleteFolderDialog } = useFolderManagement()
+
+            // Act
+            const result = await deleteFolder(folder, [backupInFolder])
+
+            // Assert: 不應該調用 DeleteFolder API，且應該返回錯誤
+            expect(mockApp.DeleteFolder).not.toHaveBeenCalled()
+            expect(result.success).toBe(false)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+  })
+
+  describe('Property 11: Toggle 狀態反轉', () => {
+    it('toggleFolder 應該反轉展開狀態', () => {
+      fc.assert(
+        fc.property(
+          fc.uuid(),
+          fc.boolean(),
+          (folderId, initialExpanded) => {
+            const { expandedFolders, toggleFolder } = useFolderManagement()
+
+            // 設定初始狀態
+            if (initialExpanded) {
+              expandedFolders.value = new Set([folderId])
+            } else {
+              expandedFolders.value = new Set()
+            }
+
+            // Act
+            toggleFolder(folderId)
+
+            // Assert
+            expect(expandedFolders.value.has(folderId)).toBe(!initialExpanded)
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('toggleUncategorized 應該反轉未分類展開狀態', () => {
+      fc.assert(
+        fc.property(
+          fc.boolean(),
+          (initialExpanded) => {
+            const { uncategorizedExpanded, toggleUncategorized } = useFolderManagement()
+
+            uncategorizedExpanded.value = initialExpanded
+
+            // Act
+            toggleUncategorized()
+
+            // Assert
+            expect(uncategorizedExpanded.value).toBe(!initialExpanded)
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  describe('Property 12: 拖放分配正確性', () => {
+    it('拖放到文件夾應該調用 AssignSnapshotToFolder', async () => {
+      // Arrange
+      const folderId = 'test-folder-id'
+      const backupNames = ['backup1', 'backup2', 'backup3']
+      mockApp.AssignSnapshotToFolder.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetFolderList.mockResolvedValue([])
+
+      const { onDropToFolder } = useFolderManagement()
+
+      // Act
+      await onDropToFolder(backupNames, folderId)
+
+      // Assert
+      expect(mockApp.AssignSnapshotToFolder).toHaveBeenCalledTimes(backupNames.length)
+      backupNames.forEach(name => {
+        expect(mockApp.AssignSnapshotToFolder).toHaveBeenCalledWith(name, folderId)
+      })
+    })
+
+    it('拖放到未分類應該調用 UnassignSnapshot', async () => {
+      // Arrange
+      const backupNames = ['backup1', 'backup2']
+      mockApp.UnassignSnapshot.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetFolderList.mockResolvedValue([])
+
+      const { onDropToUncategorized } = useFolderManagement()
+
+      // Act
+      await onDropToUncategorized(backupNames)
+
+      // Assert
+      expect(mockApp.UnassignSnapshot).toHaveBeenCalledTimes(backupNames.length)
+      backupNames.forEach(name => {
+        expect(mockApp.UnassignSnapshot).toHaveBeenCalledWith(name)
+      })
+    })
+  })
+
+  describe('Property 13: 孤兒 folderId 歸類', () => {
+    it('備份的 folderId 不存在於文件夾列表時應歸類為未分類', () => {
+      fc.assert(
+        fc.property(
+          folderListArbitrary({ minLength: 1, maxLength: 5 }),
+          backupListArbitrary({ minLength: 1, maxLength: 10 }),
+          (folders, backups) => {
+            const { getUncategorizedBackups } = useFolderManagement()
+
+            // 設定一些備份有不存在的 folderId
+            const folderIds = new Set(folders.map(f => f.id))
+            const backupsWithOrphanIds = backups.map((b, i) => ({
+              ...b,
+              folderId: i % 2 === 0 ? 'non-existent-id' : (folders[0]?.id || ''),
+            }))
+
+            // Act
+            const uncategorized = getUncategorizedBackups(backupsWithOrphanIds, folders)
+
+            // Assert: 孤兒 folderId 的備份應該在未分類中
+            const orphanBackups = backupsWithOrphanIds.filter(
+              b => b.folderId && !folderIds.has(b.folderId)
+            )
+            const emptyFolderIdBackups = backupsWithOrphanIds.filter(b => !b.folderId)
+            
+            expect(uncategorized.length).toBe(orphanBackups.length + emptyFolderIdBackups.length)
+          }
+        ),
+        { numRuns: 30 }
+      )
+    })
+  })
+
+  describe('Property 14: 批量移動文件夾分配', () => {
+    it('批量移動到文件夾應該更新所有選中備份', async () => {
+      // Arrange
+      const targetFolderId = 'target-folder-id'
+      const backupNames = ['backup1', 'backup2', 'backup3']
+      mockApp.AssignSnapshotToFolder.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetFolderList.mockResolvedValue([])
+
+      const { batchMoveToFolder } = useFolderManagement()
+
+      // Act
+      await batchMoveToFolder(backupNames, targetFolderId)
+
+      // Assert
+      expect(mockApp.AssignSnapshotToFolder).toHaveBeenCalledTimes(backupNames.length)
+      backupNames.forEach(name => {
+        expect(mockApp.AssignSnapshotToFolder).toHaveBeenCalledWith(name, targetFolderId)
+      })
+    })
+
+    it('批量移動到未分類應該取消所有選中備份的文件夾分配', async () => {
+      // Arrange
+      const backupNames = ['backup1', 'backup2']
+      mockApp.UnassignSnapshot.mockResolvedValue({ success: true, message: '' })
+      mockApp.GetFolderList.mockResolvedValue([])
+
+      const { batchMoveToFolder } = useFolderManagement()
+
+      // Act
+      await batchMoveToFolder(backupNames, null)
+
+      // Assert
+      expect(mockApp.UnassignSnapshot).toHaveBeenCalledTimes(backupNames.length)
+      backupNames.forEach(name => {
+        expect(mockApp.UnassignSnapshot).toHaveBeenCalledWith(name)
+      })
+    })
+  })
+
+  describe('拖放狀態管理', () => {
+    it('onDragEnterFolder 應該設定 dragOverFolderId', () => {
+      fc.assert(
+        fc.property(
+          fc.uuid(),
+          (folderId) => {
+            const { dragOverFolderId, dragOverUncategorized, onDragEnterFolder } = useFolderManagement()
+
+            onDragEnterFolder(folderId)
+
+            expect(dragOverFolderId.value).toBe(folderId)
+            expect(dragOverUncategorized.value).toBe(false)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+
+    it('onDragLeaveFolder 應該清除 dragOverFolderId', () => {
+      const { dragOverFolderId, onDragEnterFolder, onDragLeaveFolder } = useFolderManagement()
+
+      onDragEnterFolder('some-id')
+      expect(dragOverFolderId.value).toBe('some-id')
+
+      onDragLeaveFolder()
+      expect(dragOverFolderId.value).toBeNull()
+    })
+
+    it('onDragEnterUncategorized 應該設定 dragOverUncategorized', () => {
+      const { dragOverFolderId, dragOverUncategorized, onDragEnterUncategorized } = useFolderManagement()
+
+      onDragEnterUncategorized()
+
+      expect(dragOverUncategorized.value).toBe(true)
+      expect(dragOverFolderId.value).toBeNull()
+    })
+
+    it('cleanupDragState 應該清除所有拖放狀態', () => {
+      const {
+        dragOverFolderId,
+        dragOverUncategorized,
+        onDragEnterFolder,
+        cleanupDragState,
+      } = useFolderManagement()
+
+      onDragEnterFolder('some-id')
+      expect(dragOverFolderId.value).toBe('some-id')
+
+      cleanupDragState()
+
+      expect(dragOverFolderId.value).toBeNull()
+      expect(dragOverUncategorized.value).toBe(false)
+    })
+  })
+
+  describe('重命名狀態管理', () => {
+    it('startRenameFolder 應該設定重命名狀態', () => {
+      fc.assert(
+        fc.property(
+          folderItemArbitrary,
+          (folder) => {
+            const { renamingFolder, renameFolderName, startRenameFolder } = useFolderManagement()
+
+            startRenameFolder(folder)
+
+            expect(renamingFolder.value).toBe(folder.id)
+            expect(renameFolderName.value).toBe(folder.name)
+          }
+        ),
+        { numRuns: 20 }
+      )
+    })
+
+    it('cancelRenameFolder 應該清除重命名狀態', () => {
+      const { renamingFolder, renameFolderName, startRenameFolder, cancelRenameFolder } = useFolderManagement()
+
+      startRenameFolder({ id: 'test', name: 'Test', createdAt: '', order: 0, snapshotCount: 0 })
+      expect(renamingFolder.value).toBe('test')
+
+      cancelRenameFolder()
+
+      expect(renamingFolder.value).toBeNull()
+      expect(renameFolderName.value).toBe('')
+    })
+  })
+
+  describe('刪除對話框狀態管理', () => {
+    it('cancelDeleteFolder 應該清除刪除對話框狀態', () => {
+      const { showDeleteFolderDialog, folderToDelete, cancelDeleteFolder } = useFolderManagement()
+
+      showDeleteFolderDialog.value = true
+      folderToDelete.value = { id: 'test', name: 'Test', createdAt: '', order: 0, snapshotCount: 0 }
+
+      cancelDeleteFolder()
+
+      expect(showDeleteFolderDialog.value).toBe(false)
+      expect(folderToDelete.value).toBeNull()
+    })
+  })
+})
+
+
+// ============================================================================
+// Task 1.4: 拖放取消狀態清理測試
+// ============================================================================
+
+describe('Task 1.4: 拖放取消狀態清理', () => {
+  it('cleanupDragState 應該在 dragend 事件時被調用', () => {
+    const { dragOverFolderId, dragOverUncategorized, onDragEnterFolder, cleanupDragState } = useFolderManagement()
+    
+    // 模擬拖放進入文件夾
+    onDragEnterFolder('folder-1')
+    expect(dragOverFolderId.value).toBe('folder-1')
+    
+    // 模擬 dragend 事件調用 cleanupDragState
+    cleanupDragState()
+    
+    // 驗證狀態已清理
+    expect(dragOverFolderId.value).toBeNull()
+    expect(dragOverUncategorized.value).toBe(false)
+  })
+
+  it('cleanupDragState 應該在 ESC 鍵按下時被調用', () => {
+    const { dragOverFolderId, dragOverUncategorized, onDragEnterUncategorized, cleanupDragState } = useFolderManagement()
+    
+    // 模擬拖放進入未分類區塊
+    onDragEnterUncategorized()
+    expect(dragOverUncategorized.value).toBe(true)
+    
+    // 模擬 ESC 鍵按下調用 cleanupDragState
+    cleanupDragState()
+    
+    // 驗證狀態已清理
+    expect(dragOverFolderId.value).toBeNull()
+    expect(dragOverUncategorized.value).toBe(false)
+  })
+
+  it('cleanupDragState 應該同時清理 dragOverFolderId 和 dragOverUncategorized', () => {
+    const { dragOverFolderId, dragOverUncategorized, cleanupDragState } = useFolderManagement()
+    
+    // 手動設置狀態
+    dragOverFolderId.value = 'some-folder'
+    dragOverUncategorized.value = true
+    
+    // 調用清理
+    cleanupDragState()
+    
+    // 驗證兩個狀態都被清理
+    expect(dragOverFolderId.value).toBeNull()
+    expect(dragOverUncategorized.value).toBe(false)
+  })
+})

--- a/frontend/src/composables/__tests__/useSoftReset.spec.ts
+++ b/frontend/src/composables/__tests__/useSoftReset.spec.ts
@@ -1,0 +1,609 @@
+/**
+ * useSoftReset Composable 測試
+ * @description Property-Based Testing for 軟重置功能
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useSoftReset } from '../useSoftReset'
+import {
+  softResetStatusArbitrary,
+  hexStringArbitrary,
+  resultArbitrary,
+} from './arbitraries'
+import type { SoftResetStatus, Result } from '@/types/backup'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+  }
+})()
+
+// Mock window.go.main.App
+const createMockApp = () => ({
+  GetSoftResetStatus: vi.fn(),
+  SoftResetToNewMachine: vi.fn(),
+  RestoreSoftReset: vi.fn(),
+  RegenerateMachineID: vi.fn(),
+  RepatchExtension: vi.fn(),
+  OpenExtensionFolder: vi.fn(),
+  OpenMachineIDFolder: vi.fn(),
+  OpenSSOCacheFolder: vi.fn(),
+})
+
+let mockApp = createMockApp()
+
+// Setup global mock
+beforeEach(() => {
+  mockApp = createMockApp()
+  localStorageMock.clear()
+  vi.stubGlobal('window', {
+    go: {
+      main: {
+        App: mockApp,
+      },
+    },
+  })
+  vi.stubGlobal('localStorage', localStorageMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useSoftReset', () => {
+  describe('初始狀態', () => {
+    it('應該有正確的初始狀態', () => {
+      const {
+        softResetStatus,
+        resetting,
+        restoringOriginal,
+        patching,
+        hasUsedReset,
+        showFirstTimeResetModal,
+      } = useSoftReset()
+
+      expect(softResetStatus.value).toEqual({
+        isPatched: false,
+        hasCustomId: false,
+        customMachineId: '',
+        extensionPath: '',
+        isSupported: true,
+      })
+      expect(resetting.value).toBe(false)
+      expect(restoringOriginal.value).toBe(false)
+      expect(patching.value).toBe(false)
+      expect(hasUsedReset.value).toBe(false)
+      expect(showFirstTimeResetModal.value).toBe(false)
+    })
+  })
+
+  describe('Property 20: 軟重置機器碼變更', () => {
+    it('執行軟重置後應該調用 SoftResetToNewMachine API', async () => {
+      // Arrange
+      mockApp.SoftResetToNewMachine.mockResolvedValue({ success: true, message: '重置成功' })
+      localStorageMock.setItem('kiro-manager-has-used-reset', 'true')
+
+      const { executeReset, hasUsedReset } = useSoftReset()
+      hasUsedReset.value = true
+
+      // Act
+      const result = await executeReset()
+
+      // Assert
+      expect(mockApp.SoftResetToNewMachine).toHaveBeenCalled()
+      expect(result.success).toBe(true)
+    })
+
+    it('軟重置成功後應該設置 hasUsedReset 為 true 並保存到 localStorage', async () => {
+      // Arrange
+      mockApp.SoftResetToNewMachine.mockResolvedValue({ success: true, message: '重置成功' })
+
+      const { executeReset, hasUsedReset } = useSoftReset()
+
+      // Act
+      await executeReset()
+
+      // Assert
+      expect(hasUsedReset.value).toBe(true)
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('kiro-manager-has-used-reset', 'true')
+    })
+
+    it('軟重置失敗時不應該更新 hasUsedReset', async () => {
+      // Arrange
+      mockApp.SoftResetToNewMachine.mockResolvedValue({ success: false, message: '重置失敗' })
+
+      const { executeReset, hasUsedReset } = useSoftReset()
+      hasUsedReset.value = false
+
+      // Act
+      await executeReset()
+
+      // Assert
+      expect(hasUsedReset.value).toBe(false)
+    })
+
+    it('首次使用軟重置時應該顯示首次使用對話框', async () => {
+      // Arrange
+      const { resetToNew, hasUsedReset, showFirstTimeResetModal } = useSoftReset()
+      hasUsedReset.value = false
+
+      // Act
+      await resetToNew()
+
+      // Assert
+      expect(showFirstTimeResetModal.value).toBe(true)
+      expect(mockApp.SoftResetToNewMachine).not.toHaveBeenCalled()
+    })
+
+    it('resetting 狀態應該在執行期間為 true', async () => {
+      // Arrange
+      let resolveSoftReset: (value: Result) => void
+      mockApp.SoftResetToNewMachine.mockImplementation(() => {
+        return new Promise(resolve => {
+          resolveSoftReset = resolve
+        })
+      })
+
+      const { executeReset, resetting } = useSoftReset()
+
+      // Act
+      const resetPromise = executeReset()
+
+      // Assert - 執行期間
+      expect(resetting.value).toBe(true)
+
+      // 完成重置
+      resolveSoftReset!({ success: true, message: '' })
+      await resetPromise
+
+      // Assert - 完成後
+      expect(resetting.value).toBe(false)
+    })
+  })
+
+  describe('Property 21: 還原原始機器狀態', () => {
+    it('執行還原後應該調用 RestoreSoftReset API', async () => {
+      // Arrange
+      mockApp.RestoreSoftReset.mockResolvedValue({ success: true, message: '還原成功' })
+
+      const { restoreOriginal } = useSoftReset()
+
+      // Act
+      const result = await restoreOriginal()
+
+      // Assert
+      expect(mockApp.RestoreSoftReset).toHaveBeenCalled()
+      expect(result.success).toBe(true)
+    })
+
+    it('restoringOriginal 狀態應該在執行期間為 true', async () => {
+      // Arrange
+      let resolveRestore: (value: Result) => void
+      mockApp.RestoreSoftReset.mockImplementation(() => {
+        return new Promise(resolve => {
+          resolveRestore = resolve
+        })
+      })
+
+      const { restoreOriginal, restoringOriginal } = useSoftReset()
+
+      // Act
+      const restorePromise = restoreOriginal()
+
+      // Assert - 執行期間
+      expect(restoringOriginal.value).toBe(true)
+
+      // 完成還原
+      resolveRestore!({ success: true, message: '' })
+      await restorePromise
+
+      // Assert - 完成後
+      expect(restoringOriginal.value).toBe(false)
+    })
+
+    it('還原失敗時應該返回失敗結果', async () => {
+      // Arrange
+      mockApp.RestoreSoftReset.mockResolvedValue({ success: false, message: '還原失敗' })
+
+      const { restoreOriginal } = useSoftReset()
+
+      // Act
+      const result = await restoreOriginal()
+
+      // Assert
+      expect(result.success).toBe(false)
+      expect(result.message).toBe('還原失敗')
+    })
+  })
+
+  describe('Property 22: 備份機器碼重新生成', () => {
+    it('重新生成機器碼應該調用 RegenerateMachineID API', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 50 }),
+          async (backupName) => {
+            // Arrange
+            mockApp.RegenerateMachineID.mockResolvedValue({ success: true, message: '重新生成成功' })
+
+            const { regenerateMachineID } = useSoftReset()
+
+            // Act
+            const result = await regenerateMachineID(backupName)
+
+            // Assert
+            expect(mockApp.RegenerateMachineID).toHaveBeenCalledWith(backupName)
+            expect(result.success).toBe(true)
+          }
+        ),
+        { numRuns: 10 }
+      )
+    })
+
+    it('重新生成機器碼失敗時應該返回失敗結果', async () => {
+      // Arrange
+      mockApp.RegenerateMachineID.mockResolvedValue({ success: false, message: '重新生成失敗' })
+
+      const { regenerateMachineID } = useSoftReset()
+
+      // Act
+      const result = await regenerateMachineID('test-backup')
+
+      // Assert
+      expect(result.success).toBe(false)
+      expect(result.message).toBe('重新生成失敗')
+    })
+  })
+
+  describe('Property 23: Extension Patch 狀態', () => {
+    it('執行 Patch 後應該調用 RepatchExtension API', async () => {
+      // Arrange
+      const newStatus: SoftResetStatus = {
+        isPatched: true,
+        hasCustomId: true,
+        customMachineId: 'abc123',
+        extensionPath: '/path/to/extension',
+        isSupported: true,
+      }
+      mockApp.RepatchExtension.mockResolvedValue({ success: true, message: 'Patch 成功' })
+      mockApp.GetSoftResetStatus.mockResolvedValue(newStatus)
+
+      const { patchExtension, softResetStatus } = useSoftReset()
+
+      // Act
+      const result = await patchExtension()
+
+      // Assert
+      expect(mockApp.RepatchExtension).toHaveBeenCalled()
+      expect(result.success).toBe(true)
+      expect(softResetStatus.value).toEqual(newStatus)
+    })
+
+    it('patching 狀態應該在執行期間為 true', async () => {
+      // Arrange
+      let resolvePatch: (value: Result) => void
+      mockApp.RepatchExtension.mockImplementation(() => {
+        return new Promise(resolve => {
+          resolvePatch = resolve
+        })
+      })
+      mockApp.GetSoftResetStatus.mockResolvedValue({
+        isPatched: true,
+        hasCustomId: false,
+        customMachineId: '',
+        extensionPath: '',
+        isSupported: true,
+      })
+
+      const { patchExtension, patching } = useSoftReset()
+
+      // Act
+      const patchPromise = patchExtension()
+
+      // Assert - 執行期間
+      expect(patching.value).toBe(true)
+
+      // 完成 Patch
+      resolvePatch!({ success: true, message: '' })
+      await patchPromise
+
+      // Assert - 完成後
+      expect(patching.value).toBe(false)
+    })
+
+    it('Patch 成功後應該更新 softResetStatus', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          softResetStatusArbitrary,
+          async (newStatus) => {
+            // Arrange
+            mockApp.RepatchExtension.mockResolvedValue({ success: true, message: '' })
+            mockApp.GetSoftResetStatus.mockResolvedValue(newStatus)
+
+            const { patchExtension, softResetStatus } = useSoftReset()
+
+            // Act
+            await patchExtension()
+
+            // Assert
+            expect(softResetStatus.value).toEqual(newStatus)
+          }
+        ),
+        { numRuns: 10 }
+      )
+    })
+
+    it('Patch 失敗時不應該更新 softResetStatus', async () => {
+      // Arrange
+      mockApp.RepatchExtension.mockResolvedValue({ success: false, message: 'Patch 失敗' })
+
+      const { patchExtension, softResetStatus } = useSoftReset()
+      const initialStatus = { ...softResetStatus.value }
+
+      // Act
+      await patchExtension()
+
+      // Assert
+      expect(softResetStatus.value).toEqual(initialStatus)
+      expect(mockApp.GetSoftResetStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getSoftResetStatus', () => {
+    it('應該載入並更新 softResetStatus', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          softResetStatusArbitrary,
+          async (status) => {
+            // Arrange
+            mockApp.GetSoftResetStatus.mockResolvedValue(status)
+
+            const { getSoftResetStatus, softResetStatus } = useSoftReset()
+
+            // Act
+            await getSoftResetStatus()
+
+            // Assert
+            expect(softResetStatus.value).toEqual(status)
+          }
+        ),
+        { numRuns: 10 }
+      )
+    })
+  })
+
+  describe('loadHasUsedReset', () => {
+    it('應該從 localStorage 載入 hasUsedReset 狀態', () => {
+      // Arrange
+      localStorageMock.getItem.mockReturnValue('true')
+
+      const { loadHasUsedReset, hasUsedReset } = useSoftReset()
+
+      // Act
+      loadHasUsedReset()
+
+      // Assert
+      expect(hasUsedReset.value).toBe(true)
+      expect(localStorageMock.getItem).toHaveBeenCalledWith('kiro-manager-has-used-reset')
+    })
+
+    it('localStorage 沒有值時 hasUsedReset 應該為 false', () => {
+      // Arrange
+      localStorageMock.getItem.mockReturnValue(null)
+
+      const { loadHasUsedReset, hasUsedReset } = useSoftReset()
+
+      // Act
+      loadHasUsedReset()
+
+      // Assert
+      expect(hasUsedReset.value).toBe(false)
+    })
+  })
+
+  describe('confirmFirstTimeReset', () => {
+    it('應該關閉首次使用對話框', async () => {
+      // Arrange
+      mockApp.SoftResetToNewMachine.mockResolvedValue({ success: true, message: '' })
+
+      const { confirmFirstTimeReset, showFirstTimeResetModal } = useSoftReset()
+      showFirstTimeResetModal.value = true
+
+      // Act
+      await confirmFirstTimeReset()
+
+      // Assert
+      expect(showFirstTimeResetModal.value).toBe(false)
+    })
+
+    it('確認後應該執行重置', async () => {
+      // Arrange
+      mockApp.SoftResetToNewMachine.mockResolvedValue({ success: true, message: '' })
+
+      const { confirmFirstTimeReset, hasUsedReset } = useSoftReset()
+
+      // Act
+      await confirmFirstTimeReset()
+
+      // Assert
+      expect(mockApp.SoftResetToNewMachine).toHaveBeenCalled()
+      expect(hasUsedReset.value).toBe(true)
+    })
+  })
+
+  describe('工具方法', () => {
+    it('openExtensionFolder 應該調用 OpenExtensionFolder API', async () => {
+      // Arrange
+      mockApp.OpenExtensionFolder.mockResolvedValue(undefined)
+
+      const { openExtensionFolder } = useSoftReset()
+
+      // Act
+      await openExtensionFolder()
+
+      // Assert
+      expect(mockApp.OpenExtensionFolder).toHaveBeenCalled()
+    })
+
+    it('openMachineIDFolder 應該調用 OpenMachineIDFolder API', async () => {
+      // Arrange
+      mockApp.OpenMachineIDFolder.mockResolvedValue(undefined)
+
+      const { openMachineIDFolder } = useSoftReset()
+
+      // Act
+      await openMachineIDFolder()
+
+      // Assert
+      expect(mockApp.OpenMachineIDFolder).toHaveBeenCalled()
+    })
+
+    it('openSSOCacheFolder 應該調用 OpenSSOCacheFolder API', async () => {
+      // Arrange
+      mockApp.OpenSSOCacheFolder.mockResolvedValue(undefined)
+
+      const { openSSOCacheFolder } = useSoftReset()
+
+      // Act
+      await openSSOCacheFolder()
+
+      // Assert
+      expect(mockApp.OpenSSOCacheFolder).toHaveBeenCalled()
+    })
+  })
+
+  describe('錯誤處理', () => {
+    it('executeReset 發生異常時應該正確處理', async () => {
+      // Arrange
+      mockApp.SoftResetToNewMachine.mockRejectedValue(new Error('網路錯誤'))
+
+      const { executeReset, resetting } = useSoftReset()
+
+      // Act
+      const result = await executeReset()
+
+      // Assert
+      expect(result.success).toBe(false)
+      expect(resetting.value).toBe(false)
+    })
+
+    it('restoreOriginal 發生異常時應該正確處理', async () => {
+      // Arrange
+      mockApp.RestoreSoftReset.mockRejectedValue(new Error('網路錯誤'))
+
+      const { restoreOriginal, restoringOriginal } = useSoftReset()
+
+      // Act
+      const result = await restoreOriginal()
+
+      // Assert
+      expect(result.success).toBe(false)
+      expect(restoringOriginal.value).toBe(false)
+    })
+
+    it('patchExtension 發生異常時應該正確處理', async () => {
+      // Arrange
+      mockApp.RepatchExtension.mockRejectedValue(new Error('網路錯誤'))
+
+      const { patchExtension, patching } = useSoftReset()
+
+      // Act
+      const result = await patchExtension()
+
+      // Assert
+      expect(result.success).toBe(false)
+      expect(patching.value).toBe(false)
+    })
+  })
+})
+
+
+// ============================================================================
+// Task 1.3: patchExtension 超時保護測試
+// ============================================================================
+
+describe('Task 1.3: patchExtension 超時保護', () => {
+  it('patchExtension 應該使用 withTimeout 包裝 API 調用', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    
+    mockApp.RepatchExtension.mockImplementation(() => {
+      return new Promise(() => {
+        // 永不 resolve，模擬超時
+      })
+    })
+    
+    const { patchExtension, patching } = useSoftReset()
+    
+    // Act
+    const patchPromise = patchExtension()
+    
+    expect(patching.value).toBe(true)
+    
+    // 快進 30 秒（超時時間）
+    await vi.advanceTimersByTimeAsync(30000)
+    
+    const result = await patchPromise
+    
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('超時')
+    expect(patching.value).toBe(false)
+    
+    vi.useRealTimers()
+  })
+
+  it('patchExtension 成功時應該正常返回結果', async () => {
+    // Arrange
+    mockApp.RepatchExtension.mockResolvedValue({ success: true, message: 'Patch 成功' })
+    mockApp.GetSoftResetStatus.mockResolvedValue({
+      isPatched: true,
+      hasCustomId: false,
+      customMachineId: '',
+      extensionPath: '',
+      isSupported: true,
+    })
+    
+    const { patchExtension, patching } = useSoftReset()
+    
+    // Act
+    const result = await patchExtension()
+    
+    // Assert
+    expect(result.success).toBe(true)
+    expect(patching.value).toBe(false)
+  })
+
+  it('patchExtension 超時後 finally 區塊應該重置 patching 狀態', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    
+    mockApp.RepatchExtension.mockImplementation(() => {
+      return new Promise(() => {})
+    })
+    
+    const { patchExtension, patching } = useSoftReset()
+    
+    // Act
+    const promise = patchExtension()
+    expect(patching.value).toBe(true)
+    
+    await vi.advanceTimersByTimeAsync(31000)
+    await promise
+    
+    // Assert
+    expect(patching.value).toBe(false)
+    
+    vi.useRealTimers()
+  })
+})

--- a/frontend/src/composables/__tests__/useUIState.spec.ts
+++ b/frontend/src/composables/__tests__/useUIState.spec.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useUIState } from '../useUIState'
+import type { MenuType, ToastType } from '@/types/ui'
+
+describe('Feature: app-vue-decoupling, useUIState composable', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('Property 11: Toggle 狀態反轉', () => {
+    it('toggleMobileMenu 應反轉 isMobileMenuOpen 狀態', () => {
+      fc.assert(
+        fc.property(
+          fc.boolean(),
+          (initialState) => {
+            const { isMobileMenuOpen, toggleMobileMenu } = useUIState()
+            
+            // 設定初始狀態
+            isMobileMenuOpen.value = initialState
+            
+            // 執行 toggle
+            toggleMobileMenu()
+            
+            // 驗證：狀態應反轉
+            return isMobileMenuOpen.value === !initialState
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it('連續 toggle 兩次應回到原始狀態', () => {
+      fc.assert(
+        fc.property(
+          fc.boolean(),
+          (initialState) => {
+            const { isMobileMenuOpen, toggleMobileMenu } = useUIState()
+            
+            isMobileMenuOpen.value = initialState
+            
+            toggleMobileMenu()
+            toggleMobileMenu()
+            
+            return isMobileMenuOpen.value === initialState
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+  })
+
+  describe('Property 28: 菜單切換與移動端菜單關閉', () => {
+    it('setActiveMenu 應關閉移動端菜單', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom<MenuType>('dashboard', 'settings', 'oauth'),
+          fc.boolean(),
+          (targetMenu, mobileMenuState) => {
+            const { activeMenu, isMobileMenuOpen, setActiveMenu } = useUIState()
+            
+            // 設定初始狀態
+            isMobileMenuOpen.value = mobileMenuState
+            
+            // 執行菜單切換
+            setActiveMenu(targetMenu)
+            
+            // 驗證：
+            // 1. activeMenu 應更新為目標菜單
+            // 2. isMobileMenuOpen 應為 false
+            return activeMenu.value === targetMenu && isMobileMenuOpen.value === false
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it('setActiveMenu 應正確更新 activeMenu 狀態', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom<MenuType>('dashboard', 'settings', 'oauth'),
+          fc.constantFrom<MenuType>('dashboard', 'settings', 'oauth'),
+          (initialMenu, targetMenu) => {
+            const { activeMenu, setActiveMenu } = useUIState()
+            
+            activeMenu.value = initialMenu
+            setActiveMenu(targetMenu)
+            
+            return activeMenu.value === targetMenu
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+  })
+
+  describe('Property 29: 確認對話框 Promise 解析', () => {
+    it('showConfirmDialog 應返回 Promise，onConfirm 解析為 true', async () => {
+      const { confirmDialog, showConfirmDialog } = useUIState()
+      
+      const promise = showConfirmDialog({
+        title: 'Test Title',
+        message: 'Test Message'
+      })
+      
+      // 驗證對話框已顯示
+      expect(confirmDialog.value.show).toBe(true)
+      expect(confirmDialog.value.title).toBe('Test Title')
+      expect(confirmDialog.value.message).toBe('Test Message')
+      
+      // 模擬用戶點擊確認
+      confirmDialog.value.onConfirm()
+      
+      // 驗證 Promise 解析為 true
+      const result = await promise
+      expect(result).toBe(true)
+      expect(confirmDialog.value.show).toBe(false)
+    })
+
+    it('showConfirmDialog 應返回 Promise，onCancel 解析為 false', async () => {
+      const { confirmDialog, showConfirmDialog } = useUIState()
+      
+      const promise = showConfirmDialog({
+        title: 'Test Title',
+        message: 'Test Message'
+      })
+      
+      // 驗證對話框已顯示
+      expect(confirmDialog.value.show).toBe(true)
+      
+      // 模擬用戶點擊取消
+      confirmDialog.value.onCancel()
+      
+      // 驗證 Promise 解析為 false
+      const result = await promise
+      expect(result).toBe(false)
+      expect(confirmDialog.value.show).toBe(false)
+    })
+
+    it('showConfirmDialog 應使用預設值', async () => {
+      const { confirmDialog, showConfirmDialog } = useUIState()
+      
+      showConfirmDialog({
+        title: 'Test',
+        message: 'Message'
+      })
+      
+      // 驗證預設值
+      expect(confirmDialog.value.type).toBe('warning')
+      expect(confirmDialog.value.confirmText).toBeTruthy()
+      expect(confirmDialog.value.cancelText).toBeTruthy()
+      
+      // 清理
+      confirmDialog.value.onCancel()
+    })
+
+    it('showConfirmDialog 應接受自定義選項', async () => {
+      const { confirmDialog, showConfirmDialog } = useUIState()
+      
+      showConfirmDialog({
+        title: 'Custom Title',
+        message: 'Custom Message',
+        type: 'danger',
+        confirmText: 'Delete',
+        cancelText: 'Keep'
+      })
+      
+      expect(confirmDialog.value.type).toBe('danger')
+      expect(confirmDialog.value.confirmText).toBe('Delete')
+      expect(confirmDialog.value.cancelText).toBe('Keep')
+      
+      // 清理
+      confirmDialog.value.onCancel()
+    })
+  })
+
+  describe('Property 30: Toast 自動消失', () => {
+    it('showToast 後 toast.show 應在指定時間後變為 false', () => {
+      const { toast, showToast } = useUIState()
+      
+      // 顯示 Toast（預設 3000ms）
+      showToast('Test message', 'success')
+      
+      // 驗證 Toast 已顯示
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.message).toBe('Test message')
+      expect(toast.value.type).toBe('success')
+      
+      // 快進 2999ms - Toast 應仍顯示
+      vi.advanceTimersByTime(2999)
+      expect(toast.value.show).toBe(true)
+      
+      // 快進 1ms（總共 3000ms）- Toast 應消失
+      vi.advanceTimersByTime(1)
+      expect(toast.value.show).toBe(false)
+    })
+
+    it('showToast 應支持自定義持續時間', () => {
+      const { toast, showToast } = useUIState()
+      
+      // 顯示 Toast，自定義 5000ms
+      showToast('Custom duration', 'warning', 5000)
+      
+      expect(toast.value.show).toBe(true)
+      
+      // 快進 4999ms - Toast 應仍顯示
+      vi.advanceTimersByTime(4999)
+      expect(toast.value.show).toBe(true)
+      
+      // 快進 1ms（總共 5000ms）- Toast 應消失
+      vi.advanceTimersByTime(1)
+      expect(toast.value.show).toBe(false)
+    })
+
+    it('showToast 應支持所有 Toast 類型', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom<ToastType>('success', 'error', 'warning'),
+          fc.string({ minLength: 1, maxLength: 100 }),
+          (toastType, message) => {
+            const { toast, showToast } = useUIState()
+            
+            showToast(message, toastType)
+            
+            return (
+              toast.value.show === true &&
+              toast.value.message === message &&
+              toast.value.type === toastType
+            )
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('連續 showToast 應覆蓋前一個 Toast', () => {
+      const { toast, showToast } = useUIState()
+      
+      showToast('First message', 'success')
+      expect(toast.value.message).toBe('First message')
+      
+      showToast('Second message', 'error')
+      expect(toast.value.message).toBe('Second message')
+      expect(toast.value.type).toBe('error')
+    })
+
+    it('P1-FIX: 連續 showToast 應清除前一個計時器，防止 Toast 提前消失', () => {
+      const { toast, showToast } = useUIState()
+      
+      // 第一個 Toast，3000ms
+      showToast('First message', 'success', 3000)
+      expect(toast.value.show).toBe(true)
+      
+      // 快進 2000ms
+      vi.advanceTimersByTime(2000)
+      expect(toast.value.show).toBe(true)
+      
+      // 第二個 Toast，3000ms（應該清除第一個計時器）
+      showToast('Second message', 'error', 3000)
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.message).toBe('Second message')
+      
+      // 快進 1000ms（總共 3000ms 從第一個 Toast 開始）
+      // 如果沒有清除計時器，第一個 Toast 的計時器會在這裡觸發
+      vi.advanceTimersByTime(1000)
+      
+      // Toast 應該仍然顯示（因為第二個 Toast 的計時器還有 2000ms）
+      expect(toast.value.show).toBe(true)
+      
+      // 再快進 2000ms（第二個 Toast 的計時器到期）
+      vi.advanceTimersByTime(2000)
+      expect(toast.value.show).toBe(false)
+    })
+  })
+
+  describe('Property 32: 統一錯誤處理', () => {
+    it('handleError 應顯示錯誤 toast', () => {
+      const { toast, handleError } = useUIState()
+      
+      const error = new Error('Test error message')
+      handleError(error)
+      
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.type).toBe('error')
+      expect(toast.value.message).toBe('Test error message')
+    })
+
+    it('handleError 應處理字串錯誤', () => {
+      const { toast, handleError } = useUIState()
+      
+      handleError('String error')
+      
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.type).toBe('error')
+      expect(toast.value.message).toBe('String error')
+    })
+
+    it('handleError 應使用 fallbackMessage 當錯誤無訊息時', () => {
+      const { toast, handleError } = useUIState()
+      
+      handleError(null, 'Fallback message')
+      
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.type).toBe('error')
+      expect(toast.value.message).toBe('Fallback message')
+    })
+
+    it('handleError 應處理帶有 message 屬性的物件', () => {
+      const { toast, handleError } = useUIState()
+      
+      handleError({ message: 'Object error message' })
+      
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.type).toBe('error')
+      expect(toast.value.message).toBe('Object error message')
+    })
+
+    it('handleError 應使用預設訊息當無法提取錯誤訊息時', () => {
+      const { toast, handleError } = useUIState()
+      
+      handleError({})
+      
+      expect(toast.value.show).toBe(true)
+      expect(toast.value.type).toBe('error')
+      // 應有預設錯誤訊息
+      expect(toast.value.message).toBeTruthy()
+    })
+  })
+
+  describe('Filter 相關功能', () => {
+    it('toggleFilter 應切換 openFilter 狀態', () => {
+      const { openFilter, toggleFilter } = useUIState()
+      
+      expect(openFilter.value).toBe(null)
+      
+      toggleFilter('subscription')
+      expect(openFilter.value).toBe('subscription')
+      
+      toggleFilter('subscription')
+      expect(openFilter.value).toBe(null)
+    })
+
+    it('toggleFilter 切換到不同篩選器應更新 openFilter', () => {
+      const { openFilter, toggleFilter } = useUIState()
+      
+      toggleFilter('subscription')
+      expect(openFilter.value).toBe('subscription')
+      
+      toggleFilter('provider')
+      expect(openFilter.value).toBe('provider')
+    })
+
+    it('closeAllFilters 應關閉所有篩選器', () => {
+      const { openFilter, toggleFilter, closeAllFilters } = useUIState()
+      
+      toggleFilter('subscription')
+      expect(openFilter.value).toBe('subscription')
+      
+      closeAllFilters()
+      expect(openFilter.value).toBe(null)
+    })
+  })
+
+  describe('初始狀態', () => {
+    it('應有正確的初始值', () => {
+      const { 
+        activeMenu, 
+        isMobileMenuOpen, 
+        openFilter, 
+        toast, 
+        confirmDialog 
+      } = useUIState()
+      
+      expect(activeMenu.value).toBe('dashboard')
+      expect(isMobileMenuOpen.value).toBe(false)
+      expect(openFilter.value).toBe(null)
+      expect(toast.value.show).toBe(false)
+      expect(confirmDialog.value.show).toBe(false)
+    })
+  })
+
+  describe('P0-3: Toast Timer Cleanup', () => {
+    it('cleanupToast 應清除 Toast 計時器並隱藏 Toast', () => {
+      const { toast, showToast, cleanupToast } = useUIState()
+      
+      showToast('Test message', 'success', 5000)
+      expect(toast.value.show).toBe(true)
+      
+      // 快進 2000ms
+      vi.advanceTimersByTime(2000)
+      expect(toast.value.show).toBe(true)
+      
+      // 調用 cleanup
+      cleanupToast()
+      
+      // Toast 應立即隱藏
+      expect(toast.value.show).toBe(false)
+      
+      // 快進剩餘時間，確保沒有錯誤發生（計時器已被清除）
+      vi.advanceTimersByTime(3000)
+      expect(toast.value.show).toBe(false)
+    })
+
+    it('cleanupToast 在沒有活動 Toast 時應安全調用', () => {
+      const { toast, cleanupToast } = useUIState()
+      
+      expect(toast.value.show).toBe(false)
+      
+      // 應該不會拋出錯誤
+      expect(() => cleanupToast()).not.toThrow()
+      expect(toast.value.show).toBe(false)
+    })
+  })
+})

--- a/frontend/src/composables/__tests__/useUsageRefresh.spec.ts
+++ b/frontend/src/composables/__tests__/useUsageRefresh.spec.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useUsageRefresh } from '../useUsageRefresh'
+
+describe('Feature: app-vue-decoupling, useUsageRefresh composable', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('Property 15: 冷卻期狀態一致性', () => {
+    it('isInCooldown 應根據 countdownTimers 正確返回', () => {
+      // 使用合法的備份名稱（排除 JavaScript 保留屬性名稱）
+      const validBackupName = fc.string({ minLength: 1, maxLength: 50 })
+        .filter(name => !['__proto__', 'constructor', 'prototype'].includes(name))
+      
+      fc.assert(
+        fc.property(
+          validBackupName,
+          fc.integer({ min: 0, max: 120 }),
+          (backupName, seconds) => {
+            const { countdownTimers, isInCooldown } = useUsageRefresh()
+            
+            // 設定倒計時值
+            countdownTimers.value[backupName] = seconds
+            
+            // 驗證：isInCooldown 應與 countdownTimers > 0 一致
+            const expected = seconds > 0
+            return isInCooldown(backupName) === expected
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it('未設定的備份名稱應返回 false', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 1, maxLength: 50 }),
+          (backupName) => {
+            const { isInCooldown } = useUsageRefresh()
+            
+            // 未設定任何倒計時
+            return isInCooldown(backupName) === false
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('isCurrentInCooldown 應根據 countdownCurrentAccount 正確返回', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 120 }),
+          (seconds) => {
+            const { countdownCurrentAccount, isCurrentInCooldown } = useUsageRefresh()
+            
+            countdownCurrentAccount.value = seconds
+            
+            const expected = seconds > 0
+            return isCurrentInCooldown() === expected
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+  })
+
+  describe('Property 16: Interval 累積防護', () => {
+    it('多次調用 startCountdown 不應累積多個 interval', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 1, maxLength: 50 }),
+          fc.integer({ min: 1, max: 5 }),
+          (backupName, callCount) => {
+            const { countdownTimers, startCountdown } = useUsageRefresh()
+            const initialSeconds = 60
+            
+            // 多次調用 startCountdown
+            for (let i = 0; i < callCount; i++) {
+              startCountdown(backupName, initialSeconds)
+            }
+            
+            // 驗證初始值正確
+            if (countdownTimers.value[backupName] !== initialSeconds) {
+              return false
+            }
+            
+            // 快進 1 秒
+            vi.advanceTimersByTime(1000)
+            
+            // 驗證：只減少 1 秒（而非 callCount 秒）
+            // 這證明只有一個 interval 在運行
+            return countdownTimers.value[backupName] === initialSeconds - 1
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('多次調用 startCurrentCountdown 不應累積多個 interval', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1, max: 5 }),
+          (callCount) => {
+            const { countdownCurrentAccount, startCurrentCountdown } = useUsageRefresh()
+            const initialSeconds = 60
+            
+            // 多次調用 startCurrentCountdown
+            for (let i = 0; i < callCount; i++) {
+              startCurrentCountdown(initialSeconds)
+            }
+            
+            // 驗證初始值正確
+            if (countdownCurrentAccount.value !== initialSeconds) {
+              return false
+            }
+            
+            // 快進 1 秒
+            vi.advanceTimersByTime(1000)
+            
+            // 驗證：只減少 1 秒
+            return countdownCurrentAccount.value === initialSeconds - 1
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  describe('倒計時基本功能', () => {
+    it('startCountdown 應正確遞減倒計時', () => {
+      const { countdownTimers, startCountdown } = useUsageRefresh()
+      const backupName = 'test-backup'
+      const seconds = 5
+      
+      startCountdown(backupName, seconds)
+      
+      expect(countdownTimers.value[backupName]).toBe(5)
+      
+      vi.advanceTimersByTime(1000)
+      expect(countdownTimers.value[backupName]).toBe(4)
+      
+      vi.advanceTimersByTime(1000)
+      expect(countdownTimers.value[backupName]).toBe(3)
+      
+      vi.advanceTimersByTime(3000)
+      expect(countdownTimers.value[backupName]).toBe(0)
+      
+      // 倒計時結束後不應繼續減少
+      vi.advanceTimersByTime(1000)
+      expect(countdownTimers.value[backupName]).toBe(0)
+    })
+
+    it('startCurrentCountdown 應正確遞減倒計時', () => {
+      const { countdownCurrentAccount, startCurrentCountdown } = useUsageRefresh()
+      const seconds = 5
+      
+      startCurrentCountdown(seconds)
+      
+      expect(countdownCurrentAccount.value).toBe(5)
+      
+      vi.advanceTimersByTime(1000)
+      expect(countdownCurrentAccount.value).toBe(4)
+      
+      vi.advanceTimersByTime(4000)
+      expect(countdownCurrentAccount.value).toBe(0)
+    })
+
+    it('clearAllCountdowns 應清除所有倒計時', () => {
+      const { 
+        countdownTimers, 
+        countdownCurrentAccount, 
+        startCountdown, 
+        startCurrentCountdown,
+        clearAllCountdowns 
+      } = useUsageRefresh()
+      
+      // 啟動多個倒計時
+      startCountdown('backup1', 60)
+      startCountdown('backup2', 30)
+      startCurrentCountdown(45)
+      
+      expect(countdownTimers.value['backup1']).toBe(60)
+      expect(countdownTimers.value['backup2']).toBe(30)
+      expect(countdownCurrentAccount.value).toBe(45)
+      
+      // 清除所有倒計時
+      clearAllCountdowns()
+      
+      expect(countdownTimers.value['backup1']).toBe(0)
+      expect(countdownTimers.value['backup2']).toBe(0)
+      expect(countdownCurrentAccount.value).toBe(0)
+      
+      // 快進確認 interval 已被清除（不會繼續減少到負數）
+      vi.advanceTimersByTime(5000)
+      expect(countdownTimers.value['backup1']).toBe(0)
+      expect(countdownTimers.value['backup2']).toBe(0)
+      expect(countdownCurrentAccount.value).toBe(0)
+    })
+  })
+
+  describe('刷新狀態管理', () => {
+    it('refreshingBackup 初始值應為 null', () => {
+      const { refreshingBackup } = useUsageRefresh()
+      expect(refreshingBackup.value).toBe(null)
+    })
+
+    it('refreshingCurrent 初始值應為 false', () => {
+      const { refreshingCurrent } = useUsageRefresh()
+      expect(refreshingCurrent.value).toBe(false)
+    })
+
+    it('countdownTimers 初始值應為空物件', () => {
+      const { countdownTimers } = useUsageRefresh()
+      expect(countdownTimers.value).toEqual({})
+    })
+
+    it('countdownCurrentAccount 初始值應為 0', () => {
+      const { countdownCurrentAccount } = useUsageRefresh()
+      expect(countdownCurrentAccount.value).toBe(0)
+    })
+  })
+
+  describe('多個備份的獨立倒計時', () => {
+    it('不同備份的倒計時應獨立運行', () => {
+      const { countdownTimers, startCountdown, isInCooldown } = useUsageRefresh()
+      
+      startCountdown('backup1', 10)
+      startCountdown('backup2', 5)
+      
+      expect(countdownTimers.value['backup1']).toBe(10)
+      expect(countdownTimers.value['backup2']).toBe(5)
+      
+      vi.advanceTimersByTime(5000)
+      
+      expect(countdownTimers.value['backup1']).toBe(5)
+      expect(countdownTimers.value['backup2']).toBe(0)
+      
+      expect(isInCooldown('backup1')).toBe(true)
+      expect(isInCooldown('backup2')).toBe(false)
+    })
+  })
+
+  describe('P0-FIX: Memory Leak - cleanup 函數', () => {
+    it('cleanup 函數應該導出並可用', () => {
+      const result = useUsageRefresh()
+      
+      // 驗證 cleanup 函數存在
+      expect(result.cleanup).toBeDefined()
+      expect(typeof result.cleanup).toBe('function')
+    })
+
+    it('cleanup 應該清除所有 interval 並重置狀態', () => {
+      const { 
+        countdownTimers, 
+        countdownCurrentAccount, 
+        startCountdown, 
+        startCurrentCountdown,
+        cleanup 
+      } = useUsageRefresh()
+      
+      // 啟動多個倒計時
+      startCountdown('backup1', 60)
+      startCountdown('backup2', 30)
+      startCurrentCountdown(45)
+      
+      expect(countdownTimers.value['backup1']).toBe(60)
+      expect(countdownTimers.value['backup2']).toBe(30)
+      expect(countdownCurrentAccount.value).toBe(45)
+      
+      // 調用 cleanup
+      cleanup()
+      
+      // 驗證狀態已重置
+      expect(countdownTimers.value['backup1']).toBe(0)
+      expect(countdownTimers.value['backup2']).toBe(0)
+      expect(countdownCurrentAccount.value).toBe(0)
+      
+      // 快進確認 interval 已被清除（不會繼續減少到負數）
+      vi.advanceTimersByTime(5000)
+      expect(countdownTimers.value['backup1']).toBe(0)
+      expect(countdownTimers.value['backup2']).toBe(0)
+      expect(countdownCurrentAccount.value).toBe(0)
+    })
+  })
+})
+
+
+// ============================================================================
+// Phase 2 Task 1.3: useUsageRefresh 擴展功能測試
+// ============================================================================
+
+// Mock Wails API for useUsageRefresh tests
+const mockRefreshBackupUsage = vi.fn()
+const mockGetCurrentUsageInfo = vi.fn()
+
+describe('Phase 2 Task 1.3: useUsageRefresh 擴展功能', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRefreshBackupUsage.mockResolvedValue({ success: true, message: '' })
+    mockGetCurrentUsageInfo.mockResolvedValue({
+      subscriptionTitle: 'KIRO PRO',
+      usageLimit: 500,
+      currentUsage: 100,
+      balance: 400,
+      isLowBalance: false,
+    })
+    
+    // @ts-ignore - Partial mock for testing
+    globalThis.window = {
+      go: {
+        main: {
+          App: {
+            RefreshBackupUsage: mockRefreshBackupUsage,
+            GetCurrentUsageInfo: mockGetCurrentUsageInfo,
+          },
+        },
+      },
+    } as any
+  })
+
+  describe('refreshBackupUsageWithUpdate 含本地狀態更新', () => {
+    it('應刷新備份用量並調用 onLocalUpdate 回調', async () => {
+      const { refreshBackupUsageWithUpdate, refreshingBackup, startCountdown } = useUsageRefresh()
+      
+      const onLocalUpdate = vi.fn()
+      const backupName = 'test-backup'
+      
+      const result = await refreshBackupUsageWithUpdate(backupName, { onLocalUpdate })
+      
+      expect(mockRefreshBackupUsage).toHaveBeenCalledWith(backupName)
+      expect(result.success).toBe(true)
+      expect(onLocalUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    it('刷新過程中 refreshingBackup 應設為備份名稱', async () => {
+      let resolvePromise: (value: any) => void
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve
+      })
+      mockRefreshBackupUsage.mockReturnValue(pendingPromise)
+      
+      const { refreshBackupUsageWithUpdate, refreshingBackup } = useUsageRefresh()
+      
+      const promise = refreshBackupUsageWithUpdate('test-backup', {})
+      
+      // 驗證進行中狀態
+      expect(refreshingBackup.value).toBe('test-backup')
+      
+      // 完成操作
+      resolvePromise!({ success: true, message: '' })
+      await promise
+      
+      // 驗證狀態恢復
+      expect(refreshingBackup.value).toBe(null)
+    })
+
+    it('刷新成功後應自動啟動冷卻期倒計時', async () => {
+      const { refreshBackupUsageWithUpdate, isInCooldown } = useUsageRefresh()
+      
+      await refreshBackupUsageWithUpdate('test-backup', {})
+      
+      // 驗證冷卻期已啟動
+      expect(isInCooldown('test-backup')).toBe(true)
+    })
+
+    it('刷新失敗時不應啟動冷卻期', async () => {
+      mockRefreshBackupUsage.mockRejectedValue(new Error('刷新失敗'))
+      
+      const { refreshBackupUsageWithUpdate, isInCooldown } = useUsageRefresh()
+      
+      const result = await refreshBackupUsageWithUpdate('test-backup', {})
+      
+      expect(result.success).toBe(false)
+      expect(isInCooldown('test-backup')).toBe(false)
+    })
+
+    it('冷卻期中不應執行刷新', async () => {
+      const { refreshBackupUsageWithUpdate, startCountdown, isInCooldown } = useUsageRefresh()
+      
+      // 先啟動冷卻期
+      startCountdown('test-backup', 60)
+      expect(isInCooldown('test-backup')).toBe(true)
+      
+      // 嘗試刷新
+      const result = await refreshBackupUsageWithUpdate('test-backup', {})
+      
+      // 應該被跳過
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('冷卻期')
+      expect(mockRefreshBackupUsage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('refreshCurrentUsageWithUpdate 含本地狀態更新', () => {
+    it('應刷新當前帳號用量並調用 onLocalUpdate 回調', async () => {
+      const { refreshCurrentUsageWithUpdate, refreshingCurrent } = useUsageRefresh()
+      
+      const onLocalUpdate = vi.fn()
+      
+      const result = await refreshCurrentUsageWithUpdate({ onLocalUpdate })
+      
+      expect(mockGetCurrentUsageInfo).toHaveBeenCalled()
+      expect(result.success).toBe(true)
+      expect(onLocalUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    it('刷新過程中 refreshingCurrent 應為 true', async () => {
+      let resolvePromise: (value: any) => void
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve
+      })
+      mockGetCurrentUsageInfo.mockReturnValue(pendingPromise)
+      
+      const { refreshCurrentUsageWithUpdate, refreshingCurrent } = useUsageRefresh()
+      
+      const promise = refreshCurrentUsageWithUpdate({})
+      
+      // 驗證進行中狀態
+      expect(refreshingCurrent.value).toBe(true)
+      
+      // 完成操作
+      resolvePromise!({ success: true, message: '' })
+      await promise
+      
+      // 驗證狀態恢復
+      expect(refreshingCurrent.value).toBe(false)
+    })
+
+    it('刷新成功後應自動啟動當前帳號冷卻期', async () => {
+      const { refreshCurrentUsageWithUpdate, isCurrentInCooldown } = useUsageRefresh()
+      
+      await refreshCurrentUsageWithUpdate({})
+      
+      // 驗證冷卻期已啟動
+      expect(isCurrentInCooldown()).toBe(true)
+    })
+
+    it('刷新失敗時不應啟動冷卻期', async () => {
+      mockGetCurrentUsageInfo.mockRejectedValue(new Error('刷新失敗'))
+      
+      const { refreshCurrentUsageWithUpdate, isCurrentInCooldown } = useUsageRefresh()
+      
+      const result = await refreshCurrentUsageWithUpdate({})
+      
+      expect(result.success).toBe(false)
+      expect(isCurrentInCooldown()).toBe(false)
+    })
+
+    it('冷卻期中不應執行刷新', async () => {
+      const { refreshCurrentUsageWithUpdate, startCurrentCountdown, isCurrentInCooldown } = useUsageRefresh()
+      
+      // 先啟動冷卻期
+      startCurrentCountdown(60)
+      expect(isCurrentInCooldown()).toBe(true)
+      
+      // 嘗試刷新
+      const result = await refreshCurrentUsageWithUpdate({})
+      
+      // 應該被跳過
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('冷卻期')
+      expect(mockGetCurrentUsageInfo).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/composables/useAppSettings.ts
+++ b/frontend/src/composables/useAppSettings.ts
@@ -1,0 +1,348 @@
+/**
+ * useAppSettings Composable
+ * @description 應用設定核心 Composable，負責管理 Kiro 版本號、安裝路徑、低餘額閾值、語言切換等功能
+ * @see App.vue - 原始實作參考
+ * @requirements 6.1-6.8
+ */
+import { ref, type Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { AppSettings, Result } from '@/types/backup'
+
+/**
+ * 路徑偵測狀態類型
+ */
+export type PathDetectionStatus = 'auto' | 'custom' | 'none'
+
+/**
+ * 應用設定 Composable 返回類型
+ */
+export interface UseAppSettingsReturn {
+  // 狀態
+  appSettings: Ref<AppSettings>
+  kiroVersionInput: Ref<string>
+  kiroVersionModified: Ref<boolean>
+  kiroInstallPathInput: Ref<string>
+  kiroInstallPathModified: Ref<boolean>
+  thresholdPreview: Ref<number>
+  detectingVersion: Ref<boolean>
+  detectingPath: Ref<boolean>
+
+  // 方法
+  loadSettings: () => Promise<void>
+  saveKiroVersion: () => Promise<void>
+  detectKiroVersion: () => Promise<void>
+  saveKiroInstallPath: () => Promise<void>
+  detectKiroInstallPath: () => Promise<void>
+  clearKiroInstallPath: () => Promise<void>
+  saveLowBalanceThreshold: (
+    value: number,
+    onLocalUpdate?: (threshold: number) => void
+  ) => Promise<void>
+  switchLanguage: (lang: string) => void
+  onKiroVersionInput: () => void
+  onKiroInstallPathInput: () => void
+  checkPathDetectionStatus: (
+    customPath: string,
+    useAutoDetect: boolean
+  ) => PathDetectionStatus
+}
+
+/** localStorage key for language */
+const LANG_STORAGE_KEY = 'kiro-manager-lang'
+
+/**
+ * 應用設定 Composable
+ * @returns 應用設定相關的狀態和方法
+ */
+export function useAppSettings(): UseAppSettingsReturn {
+  const { locale } = useI18n()
+
+  // ============================================================================
+  // 狀態定義
+  // ============================================================================
+
+  /** 應用設定 */
+  const appSettings = ref<AppSettings>({
+    lowBalanceThreshold: 0.2,
+    kiroVersion: '0.8.206',
+    useAutoDetect: true,
+    customKiroInstallPath: '',
+  })
+
+  /** Kiro 版本號輸入值 */
+  const kiroVersionInput = ref<string>('0.8.206')
+
+  /** 追蹤版本號是否被用戶手動修改 */
+  const kiroVersionModified = ref<boolean>(false)
+
+  /** Kiro 安裝路徑輸入值 */
+  const kiroInstallPathInput = ref<string>('')
+
+  /** 追蹤路徑是否被用戶手動修改 */
+  const kiroInstallPathModified = ref<boolean>(false)
+
+  /** 低餘額閾值預覽值（拖動滑桿時實時更新） */
+  const thresholdPreview = ref<number>(20)
+
+  /** 偵測版本中狀態 */
+  const detectingVersion = ref<boolean>(false)
+
+  /** 偵測路徑中狀態 */
+  const detectingPath = ref<boolean>(false)
+
+  // ============================================================================
+  // 方法
+  // ============================================================================
+
+  /**
+   * 載入應用設定
+   */
+  const loadSettings = async (): Promise<void> => {
+    try {
+      appSettings.value = await window.go.main.App.GetSettings()
+      thresholdPreview.value = Math.round(appSettings.value.lowBalanceThreshold * 100)
+      kiroVersionInput.value = appSettings.value.kiroVersion || '0.8.206'
+      kiroVersionModified.value = false
+      kiroInstallPathInput.value = appSettings.value.customKiroInstallPath || ''
+      kiroInstallPathModified.value = false
+    } catch (e) {
+      console.error('Failed to load settings:', e)
+    }
+  }
+
+  /**
+   * 儲存 Kiro 版本號
+   * @description 儲存自定義版本時，關閉自動偵測模式
+   * @requirements 6.1 - 版本號保存與自動偵測互斥
+   */
+  const saveKiroVersion = async (): Promise<void> => {
+    const version = kiroVersionInput.value.trim()
+    if (!version) return
+
+    try {
+      const result = await window.go.main.App.SaveSettings({
+        lowBalanceThreshold: appSettings.value.lowBalanceThreshold,
+        kiroVersion: version,
+        useAutoDetect: false, // Property 24: 保存版本號時關閉自動偵測
+        customKiroInstallPath: appSettings.value.customKiroInstallPath,
+      })
+      if (result.success) {
+        appSettings.value.kiroVersion = version
+        appSettings.value.useAutoDetect = false
+        kiroVersionModified.value = false
+      }
+    } catch (e) {
+      console.error('Failed to save Kiro version:', e)
+    }
+  }
+
+  /**
+   * 自動偵測 Kiro 版本並啟用自動偵測模式
+   * @description 偵測成功後啟用自動偵測模式
+   * @requirements 6.2 - 版本號保存與自動偵測互斥
+   */
+  const detectKiroVersion = async (): Promise<void> => {
+    detectingVersion.value = true
+    try {
+      const result = await window.go.main.App.GetDetectedKiroVersion()
+      if (result.success) {
+        kiroVersionInput.value = result.message
+        // Property 24: 自動偵測時啟用 useAutoDetect
+        const saveResult = await window.go.main.App.SaveSettings({
+          lowBalanceThreshold: appSettings.value.lowBalanceThreshold,
+          kiroVersion: result.message,
+          useAutoDetect: true,
+          customKiroInstallPath: appSettings.value.customKiroInstallPath,
+        })
+        if (saveResult.success) {
+          appSettings.value.kiroVersion = result.message
+          appSettings.value.useAutoDetect = true
+          kiroVersionModified.value = false
+        }
+      }
+    } catch (e) {
+      console.error('Failed to detect Kiro version:', e)
+    } finally {
+      detectingVersion.value = false
+    }
+  }
+
+  /**
+   * 儲存自定義安裝路徑
+   * @requirements 6.3
+   */
+  const saveKiroInstallPath = async (): Promise<void> => {
+    const path = kiroInstallPathInput.value.trim()
+
+    try {
+      const result = await window.go.main.App.SaveSettings({
+        lowBalanceThreshold: appSettings.value.lowBalanceThreshold,
+        kiroVersion: appSettings.value.kiroVersion,
+        useAutoDetect: appSettings.value.useAutoDetect,
+        customKiroInstallPath: path,
+      })
+      if (result.success) {
+        appSettings.value.customKiroInstallPath = path
+        kiroInstallPathModified.value = false
+      }
+    } catch (e) {
+      console.error('Failed to save Kiro install path:', e)
+    }
+  }
+
+  /**
+   * 自動偵測 Kiro 安裝路徑
+   * @requirements 6.4
+   */
+  const detectKiroInstallPath = async (): Promise<void> => {
+    detectingPath.value = true
+    try {
+      const result = await window.go.main.App.GetDetectedKiroInstallPath()
+      if (result.success) {
+        kiroInstallPathInput.value = result.message
+        const saveResult = await window.go.main.App.SaveSettings({
+          lowBalanceThreshold: appSettings.value.lowBalanceThreshold,
+          kiroVersion: appSettings.value.kiroVersion,
+          useAutoDetect: appSettings.value.useAutoDetect,
+          customKiroInstallPath: result.message,
+        })
+        if (saveResult.success) {
+          appSettings.value.customKiroInstallPath = result.message
+          kiroInstallPathModified.value = false
+        }
+      }
+    } catch (e) {
+      console.error('Failed to detect Kiro install path:', e)
+    } finally {
+      detectingPath.value = false
+    }
+  }
+
+  /**
+   * 清除自定義安裝路徑（恢復自動偵測）
+   * @description Property 25: 清除路徑時將 customKiroInstallPath 設為空字串
+   * @requirements 6.5
+   */
+  const clearKiroInstallPath = async (): Promise<void> => {
+    try {
+      const result = await window.go.main.App.SaveSettings({
+        lowBalanceThreshold: appSettings.value.lowBalanceThreshold,
+        kiroVersion: appSettings.value.kiroVersion,
+        useAutoDetect: appSettings.value.useAutoDetect,
+        customKiroInstallPath: '',
+      })
+      if (result.success) {
+        appSettings.value.customKiroInstallPath = ''
+        kiroInstallPathInput.value = ''
+        kiroInstallPathModified.value = false
+      }
+    } catch (e) {
+      console.error('Failed to clear Kiro install path:', e)
+    }
+  }
+
+  /**
+   * 儲存低餘額閾值
+   * @description Property 26: 儲存後調用回調函數更新本地 isLowBalance 狀態
+   * @param value 閾值 (0.0 ~ 1.0)
+   * @param onLocalUpdate 本地更新回調函數
+   * @requirements 6.6
+   */
+  const saveLowBalanceThreshold = async (
+    value: number,
+    onLocalUpdate?: (threshold: number) => void
+  ): Promise<void> => {
+    try {
+      const result = await window.go.main.App.SaveSettings({
+        lowBalanceThreshold: value,
+        kiroVersion: appSettings.value.kiroVersion,
+        useAutoDetect: appSettings.value.useAutoDetect,
+        customKiroInstallPath: appSettings.value.customKiroInstallPath,
+      })
+      if (result.success) {
+        appSettings.value.lowBalanceThreshold = value
+        // Property 26: 調用回調函數更新本地 isLowBalance 狀態
+        if (onLocalUpdate) {
+          onLocalUpdate(value)
+        }
+      }
+    } catch (e) {
+      console.error('Failed to save low balance threshold:', e)
+    }
+  }
+
+  /**
+   * 切換語言
+   * @description Property 27: 將語言設定存入 localStorage
+   * @param lang 語言代碼
+   * @requirements 6.7
+   */
+  const switchLanguage = (lang: string): void => {
+    locale.value = lang
+    localStorage.setItem(LANG_STORAGE_KEY, lang)
+  }
+
+  /**
+   * 處理版本號輸入變更
+   * @requirements 6.8
+   */
+  const onKiroVersionInput = (): void => {
+    kiroVersionModified.value = true
+  }
+
+  /**
+   * 處理安裝路徑輸入變更
+   * @requirements 6.8
+   */
+  const onKiroInstallPathInput = (): void => {
+    kiroInstallPathModified.value = true
+  }
+
+  /**
+   * 檢查路徑偵測狀態
+   * @param customPath 自定義路徑
+   * @param useAutoDetect 是否使用自動偵測
+   * @returns 路徑偵測狀態
+   */
+  const checkPathDetectionStatus = (
+    customPath: string,
+    useAutoDetect: boolean
+  ): PathDetectionStatus => {
+    if (customPath) {
+      return 'custom'
+    }
+    if (useAutoDetect) {
+      return 'auto'
+    }
+    return 'none'
+  }
+
+  // ============================================================================
+  // 返回
+  // ============================================================================
+
+  return {
+    // 狀態
+    appSettings,
+    kiroVersionInput,
+    kiroVersionModified,
+    kiroInstallPathInput,
+    kiroInstallPathModified,
+    thresholdPreview,
+    detectingVersion,
+    detectingPath,
+
+    // 方法
+    loadSettings,
+    saveKiroVersion,
+    detectKiroVersion,
+    saveKiroInstallPath,
+    detectKiroInstallPath,
+    clearKiroInstallPath,
+    saveLowBalanceThreshold,
+    switchLanguage,
+    onKiroVersionInput,
+    onKiroInstallPathInput,
+    checkPathDetectionStatus,
+  }
+}

--- a/frontend/src/composables/useAutoSwitch.ts
+++ b/frontend/src/composables/useAutoSwitch.ts
@@ -1,0 +1,284 @@
+/**
+ * useAutoSwitch Composable
+ * @description 自動切換核心 Composable，負責管理自動切換設定、監控狀態等功能
+ * @see App.vue - 原始實作參考
+ */
+import { ref, type Ref } from 'vue'
+import type { AutoSwitchSettings, AutoSwitchStatus, RefreshIntervalRule, Result } from '@/types/backup'
+
+/**
+ * 自動切換 Composable 返回類型
+ */
+export interface UseAutoSwitchReturn {
+  // 狀態
+  autoSwitchSettings: Ref<AutoSwitchSettings>
+  autoSwitchStatus: Ref<AutoSwitchStatus>
+  savingAutoSwitch: Ref<boolean>
+  isToggling: Ref<boolean>  // P1-FIX: 並發保護狀態
+
+  // 方法
+  loadAutoSwitchSettings: () => Promise<void>
+  saveAutoSwitchSettings: () => Promise<Result>
+  toggleAutoSwitch: () => Promise<Result>
+  handleAutoSwitchToggle: (enabled: boolean) => Promise<void>
+
+  // 文件夾篩選方法
+  addAutoSwitchFolder: (folderId: string) => Promise<void>
+  removeAutoSwitchFolder: (folderId: string) => Promise<void>
+
+  // 訂閱類型篩選方法
+  addAutoSwitchSubscription: (subType: string) => Promise<void>
+  removeAutoSwitchSubscription: (subType: string) => Promise<void>
+
+  // 刷新規則方法
+  addRefreshRule: () => void
+  removeRefreshRule: (index: number) => Promise<void>
+}
+
+/**
+ * 自動切換 Composable
+ * @returns 自動切換相關的狀態和方法
+ */
+export function useAutoSwitch(): UseAutoSwitchReturn {
+  // ============================================================================
+  // 狀態定義
+  // ============================================================================
+
+  /** 自動切換設定 */
+  const autoSwitchSettings = ref<AutoSwitchSettings>({
+    enabled: false,
+    balanceThreshold: 5,
+    minTargetBalance: 50,
+    folderIds: [],
+    subscriptionTypes: [],
+    refreshIntervals: [],
+    notifyOnSwitch: true,
+    notifyOnLowBalance: true,
+  })
+
+  /** 自動切換狀態 */
+  const autoSwitchStatus = ref<AutoSwitchStatus>({
+    status: 'stopped',
+    lastBalance: 0,
+    cooldownRemaining: 0,
+    switchCount: 0,
+  })
+
+  /** 是否正在保存設定 */
+  const savingAutoSwitch = ref<boolean>(false)
+
+  /** P1-FIX: 是否正在切換（並發保護） */
+  const isToggling = ref<boolean>(false)
+
+  // ============================================================================
+  // 方法
+  // ============================================================================
+
+  /**
+   * 載入自動切換設定
+   */
+  const loadAutoSwitchSettings = async (): Promise<void> => {
+    try {
+      const settings = await window.go.main.App.GetAutoSwitchSettings()
+      autoSwitchSettings.value = {
+        enabled: settings.enabled,
+        balanceThreshold: settings.balanceThreshold,
+        minTargetBalance: settings.minTargetBalance,
+        folderIds: settings.folderIds,
+        subscriptionTypes: settings.subscriptionTypes,
+        refreshIntervals: settings.refreshIntervals,
+        notifyOnSwitch: settings.notifyOnSwitch,
+        notifyOnLowBalance: settings.notifyOnLowBalance,
+      }
+      const status = await window.go.main.App.GetAutoSwitchStatus()
+      autoSwitchStatus.value = {
+        status: status.status as 'stopped' | 'running' | 'cooldown',
+        lastBalance: status.lastBalance,
+        cooldownRemaining: status.cooldownRemaining,
+        switchCount: status.switchCount,
+      }
+    } catch (e) {
+      console.error('Failed to load auto switch settings:', e)
+    }
+  }
+
+  /**
+   * 保存自動切換設定
+   * @returns 操作結果
+   */
+  const saveAutoSwitchSettings = async (): Promise<Result> => {
+    savingAutoSwitch.value = true
+    try {
+      // 使用 as any 繞過 Wails 生成的 DTO 類型中的 convertValues 方法要求
+      const result = await window.go.main.App.SaveAutoSwitchSettings(autoSwitchSettings.value as any)
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '保存設定失敗' }
+    } finally {
+      savingAutoSwitch.value = false
+    }
+  }
+
+  /**
+   * 切換自動切換狀態
+   * @description P1-FIX: 新增並發保護，防止快速連續點擊導致狀態錯亂
+   * @returns 操作結果
+   */
+  const toggleAutoSwitch = async (): Promise<Result> => {
+    // P1-FIX: 並發保護
+    if (isToggling.value) {
+      return { success: false, message: '操作進行中' }
+    }
+    isToggling.value = true
+
+    try {
+      // 先保存設定，確保後端有最新的 Enabled 狀態
+      await saveAutoSwitchSettings()
+
+      if (autoSwitchSettings.value.enabled) {
+        const result = await window.go.main.App.StartAutoSwitchMonitor()
+        if (!result.success) {
+          // 啟動失敗，回滾 enabled 狀態
+          autoSwitchSettings.value.enabled = false
+          await saveAutoSwitchSettings()
+          // 刷新狀態顯示
+          const status = await window.go.main.App.GetAutoSwitchStatus()
+          autoSwitchStatus.value = {
+            status: status.status as 'stopped' | 'running' | 'cooldown',
+            lastBalance: status.lastBalance,
+            cooldownRemaining: status.cooldownRemaining,
+            switchCount: status.switchCount,
+          }
+          return result
+        }
+      } else {
+        await window.go.main.App.StopAutoSwitchMonitor()
+      }
+
+      // 刷新狀態顯示
+      const status = await window.go.main.App.GetAutoSwitchStatus()
+      autoSwitchStatus.value = {
+        status: status.status as 'stopped' | 'running' | 'cooldown',
+        lastBalance: status.lastBalance,
+        cooldownRemaining: status.cooldownRemaining,
+        switchCount: status.switchCount,
+      }
+      return { success: true, message: '' }
+    } finally {
+      isToggling.value = false
+    }
+  }
+
+  /**
+   * 處理自動切換開關事件
+   * @param enabled 是否啟用
+   */
+  const handleAutoSwitchToggle = async (enabled: boolean): Promise<void> => {
+    autoSwitchSettings.value.enabled = enabled
+    await toggleAutoSwitch()
+  }
+
+  // ============================================================================
+  // 文件夾篩選方法
+  // ============================================================================
+
+  /**
+   * 添加自動切換文件夾
+   * @param folderId 文件夾 ID
+   */
+  const addAutoSwitchFolder = async (folderId: string): Promise<void> => {
+    if (!folderId || autoSwitchSettings.value.folderIds.includes(folderId)) {
+      return
+    }
+    autoSwitchSettings.value.folderIds.push(folderId)
+    await saveAutoSwitchSettings()
+  }
+
+  /**
+   * 移除自動切換文件夾
+   * @param folderId 文件夾 ID
+   */
+  const removeAutoSwitchFolder = async (folderId: string): Promise<void> => {
+    autoSwitchSettings.value.folderIds = autoSwitchSettings.value.folderIds.filter(id => id !== folderId)
+    await saveAutoSwitchSettings()
+  }
+
+  // ============================================================================
+  // 訂閱類型篩選方法
+  // ============================================================================
+
+  /**
+   * 添加自動切換訂閱類型
+   * @param subType 訂閱類型
+   */
+  const addAutoSwitchSubscription = async (subType: string): Promise<void> => {
+    if (!subType || autoSwitchSettings.value.subscriptionTypes.includes(subType)) {
+      return
+    }
+    autoSwitchSettings.value.subscriptionTypes.push(subType)
+    await saveAutoSwitchSettings()
+  }
+
+  /**
+   * 移除自動切換訂閱類型
+   * @param subType 訂閱類型
+   */
+  const removeAutoSwitchSubscription = async (subType: string): Promise<void> => {
+    autoSwitchSettings.value.subscriptionTypes = autoSwitchSettings.value.subscriptionTypes.filter(s => s !== subType)
+    await saveAutoSwitchSettings()
+  }
+
+  // ============================================================================
+  // 刷新規則方法
+  // ============================================================================
+
+  /**
+   * 添加刷新規則
+   */
+  const addRefreshRule = (): void => {
+    autoSwitchSettings.value.refreshIntervals.push({
+      minBalance: 0,
+      maxBalance: -1,
+      interval: 60,
+    })
+  }
+
+  /**
+   * 移除刷新規則
+   * @param index 規則索引
+   */
+  const removeRefreshRule = async (index: number): Promise<void> => {
+    autoSwitchSettings.value.refreshIntervals.splice(index, 1)
+    await saveAutoSwitchSettings()
+  }
+
+  // ============================================================================
+  // 返回
+  // ============================================================================
+
+  return {
+    // 狀態
+    autoSwitchSettings,
+    autoSwitchStatus,
+    savingAutoSwitch,
+    isToggling,  // P1-FIX: 導出並發保護狀態
+
+    // 方法
+    loadAutoSwitchSettings,
+    saveAutoSwitchSettings,
+    toggleAutoSwitch,
+    handleAutoSwitchToggle,
+
+    // 文件夾篩選方法
+    addAutoSwitchFolder,
+    removeAutoSwitchFolder,
+
+    // 訂閱類型篩選方法
+    addAutoSwitchSubscription,
+    removeAutoSwitchSubscription,
+
+    // 刷新規則方法
+    addRefreshRule,
+    removeRefreshRule,
+  }
+}

--- a/frontend/src/composables/useBackupManagement.ts
+++ b/frontend/src/composables/useBackupManagement.ts
@@ -1,0 +1,573 @@
+/**
+ * useBackupManagement Composable
+ * @description 備份管理核心 Composable，負責管理備份列表、篩選、批量操作等功能
+ * @see App.vue - 原始實作參考
+ */
+import { ref, computed, type Ref, type ComputedRef } from 'vue'
+import type { BackupItem, Result, BatchResult } from '@/types/backup'
+import { withTimeout, TimeoutError } from '@/utils/withTimeout'
+
+/** 操作超時時間（毫秒） */
+const OPERATION_TIMEOUT_MS = 30000
+
+/**
+ * loadFullBackupData 選項
+ */
+export interface LoadFullBackupDataOptions {
+  onComplete?: () => void
+  onError?: (error: Error) => void
+}
+
+/**
+ * 備份管理 Composable 返回類型
+ */
+export interface UseBackupManagementReturn {
+  // 狀態
+  backups: Ref<BackupItem[]>
+  currentMachineId: Ref<string>
+  currentEnvironmentName: Ref<string>
+  isLoadingBackups: Ref<boolean>
+  searchQuery: Ref<string>
+  filterSubscription: Ref<string>
+  filterProvider: Ref<string>
+  filterBalance: Ref<string>
+  selectedBackups: Ref<Set<string>>
+  batchOperating: Ref<boolean>
+  creatingBackup: Ref<boolean>
+  switchingBackup: Ref<string | null>
+  deletingBackup: Ref<string | null>
+  regeneratingId: Ref<string | null>
+
+  // 計算屬性
+  activeBackup: ComputedRef<BackupItem | null>
+  filteredBackups: ComputedRef<BackupItem[]>
+
+  // 方法
+  loadBackups: (showOverlay?: boolean) => Promise<void>
+  loadFullBackupData: (options?: LoadFullBackupDataOptions) => Promise<void>
+  createBackup: (name: string) => Promise<Result>
+  switchToBackup: (name: string) => Promise<Result>
+  deleteBackup: (name: string) => Promise<Result>
+  regenerateMachineID: (name: string) => Promise<Result>
+  setFilterSubscription: (value: string) => void
+  setFilterProvider: (value: string) => void
+  setFilterBalance: (value: string) => void
+  toggleSelect: (name: string) => void
+  toggleSelectAll: () => void
+  batchDelete: () => Promise<BatchResult>
+  batchRegenerateMachineID: () => Promise<BatchResult>
+  batchRefreshUsage: (isInCooldown: (name: string) => boolean) => Promise<BatchResult>
+}
+
+/**
+ * 備份管理 Composable
+ * @returns 備份管理相關的狀態和方法
+ */
+export function useBackupManagement(): UseBackupManagementReturn {
+  // ============================================================================
+  // 狀態定義
+  // ============================================================================
+  
+  /** 備份列表 */
+  const backups = ref<BackupItem[]>([])
+  
+  /** 當前機器 ID */
+  const currentMachineId = ref<string>('')
+  
+  /** 當前環境名稱 */
+  const currentEnvironmentName = ref<string>('')
+  
+  /** 是否正在載入備份（P0: 防止並發） */
+  const isLoadingBackups = ref<boolean>(false)
+  
+  /** 搜尋關鍵字 */
+  const searchQuery = ref<string>('')
+  
+  /** 訂閱篩選 */
+  const filterSubscription = ref<string>('')
+  
+  /** 提供者篩選 */
+  const filterProvider = ref<string>('')
+  
+  /** 餘額篩選 */
+  const filterBalance = ref<string>('')
+  
+  /** 已選擇的備份 */
+  const selectedBackups = ref<Set<string>>(new Set())
+  
+  /** 批量操作進行中 */
+  const batchOperating = ref<boolean>(false)
+  
+  /** 創建備份進行中 */
+  const creatingBackup = ref<boolean>(false)
+  
+  /** 正在切換的備份 */
+  const switchingBackup = ref<string | null>(null)
+  
+  /** 正在刪除的備份 */
+  const deletingBackup = ref<string | null>(null)
+  
+  /** 正在重新生成機器碼的備份 */
+  const regeneratingId = ref<string | null>(null)
+
+
+  // ============================================================================
+  // 計算屬性
+  // ============================================================================
+  
+  /**
+   * 當前使用中的備份
+   */
+  const activeBackup = computed<BackupItem | null>(() => {
+    return backups.value.find(b => b.isCurrent) || null
+  })
+
+  /**
+   * 篩選後的備份列表
+   * @description 根據訂閱、提供者、餘額和搜尋關鍵字進行篩選
+   */
+  const filteredBackups = computed<BackupItem[]>(() => {
+    let result = backups.value
+
+    // 1. 訂閱方案篩選（精確匹配）
+    if (filterSubscription.value) {
+      const subscriptionMap: Record<string, string> = {
+        'FREE': 'KIRO FREE',
+        'PRO': 'KIRO PRO',
+        'PRO+': 'KIRO PRO+',
+        'POWER': 'KIRO POWER'
+      }
+      const target = subscriptionMap[filterSubscription.value]
+      result = result.filter(b => b.subscriptionTitle?.toUpperCase() === target)
+    }
+
+    // 2. 來源篩選（AWS 含 BuilderId）
+    if (filterProvider.value) {
+      if (filterProvider.value === 'AWS') {
+        result = result.filter(b => b.provider === 'AWS' || b.provider === 'BuilderId')
+      } else {
+        result = result.filter(b => b.provider === filterProvider.value)
+      }
+    }
+
+    // 3. 餘額篩選
+    if (filterBalance.value) {
+      if (filterBalance.value === 'LOW') {
+        result = result.filter(b => b.usageLimit > 0 && b.isLowBalance)
+      } else if (filterBalance.value === 'NORMAL') {
+        result = result.filter(b => b.usageLimit > 0 && !b.isLowBalance)
+      } else if (filterBalance.value === 'NO_DATA') {
+        result = result.filter(b => b.usageLimit === 0)
+      }
+    }
+
+    // 4. 文字搜尋
+    if (searchQuery.value.trim()) {
+      const query = searchQuery.value.toLowerCase()
+      result = result.filter(b =>
+        b.name.toLowerCase().includes(query) ||
+        b.machineId?.toLowerCase().includes(query) ||
+        b.provider?.toLowerCase().includes(query)
+      )
+    }
+
+    return result
+  })
+
+
+  // ============================================================================
+  // 方法
+  // ============================================================================
+
+  /**
+   * 載入備份列表
+   * @param showOverlay 是否顯示載入覆蓋層（預設 true）
+   * @description 包含 P0 競態條件防護：防止並發調用
+   */
+  const loadBackups = async (showOverlay: boolean = true): Promise<void> => {
+    // P0: 防止並發調用
+    if (isLoadingBackups.value) return
+    isLoadingBackups.value = true
+
+    try {
+      backups.value = await window.go.main.App.GetBackupList() || []
+      currentMachineId.value = await window.go.main.App.GetCurrentMachineID()
+      currentEnvironmentName.value = await window.go.main.App.GetCurrentEnvironmentName()
+    } catch (e) {
+      console.error('Failed to load backups:', e)
+    } finally {
+      isLoadingBackups.value = false
+    }
+  }
+
+  /**
+   * 整合載入備份數據（備份列表 + 設定 + 狀態）
+   * @param options 選項，包含 onComplete 和 onError 回調
+   * @description Phase 2 Task 1.1: 整合載入方法
+   */
+  const loadFullBackupData = async (options: LoadFullBackupDataOptions = {}): Promise<void> => {
+    const { onComplete, onError } = options
+    
+    // P0: 防止並發調用
+    if (isLoadingBackups.value) return
+    isLoadingBackups.value = true
+
+    try {
+      backups.value = await window.go.main.App.GetBackupList() || []
+      currentMachineId.value = await window.go.main.App.GetCurrentMachineID()
+      currentEnvironmentName.value = await window.go.main.App.GetCurrentEnvironmentName()
+      
+      onComplete?.()
+    } catch (e) {
+      console.error('Failed to load full backup data:', e)
+      onError?.(e as Error)
+    } finally {
+      isLoadingBackups.value = false
+    }
+  }
+
+  /**
+   * 創建備份
+   * @param name 備份名稱
+   * @returns 操作結果
+   */
+  const createBackup = async (name: string): Promise<Result> => {
+    if (!name.trim()) {
+      return { success: false, message: '備份名稱不能為空' }
+    }
+
+    // 檢查是否已存在同名備份
+    const exists = backups.value.some(b => b.name === name)
+    if (exists) {
+      return { success: false, message: '備份名稱已存在' }
+    }
+
+    creatingBackup.value = true
+    try {
+      const result = await window.go.main.App.CreateBackup(name)
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '創建備份失敗' }
+    } finally {
+      creatingBackup.value = false
+    }
+  }
+
+  /**
+   * 切換到指定備份
+   * @param name 備份名稱
+   * @returns 操作結果
+   */
+  const switchToBackup = async (name: string): Promise<Result> => {
+    if (!name) {
+      return { success: false, message: '請選擇備份' }
+    }
+
+    switchingBackup.value = name
+    try {
+      const result = await window.go.main.App.SwitchToBackup(name)
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '切換備份失敗' }
+    } finally {
+      switchingBackup.value = null
+    }
+  }
+
+  /**
+   * 刪除備份
+   * @param name 備份名稱
+   * @returns 操作結果
+   * @description 包含 30 秒超時保護
+   */
+  const deleteBackup = async (name: string): Promise<Result> => {
+    if (!name) {
+      return { success: false, message: '請選擇備份' }
+    }
+
+    deletingBackup.value = name
+    try {
+      const result = await withTimeout(
+        window.go.main.App.DeleteBackup(name),
+        OPERATION_TIMEOUT_MS,
+        '刪除備份操作超時'
+      )
+      return result
+    } catch (e: any) {
+      if (e instanceof TimeoutError) {
+        return { success: false, message: e.message }
+      }
+      return { success: false, message: e.message || '刪除備份失敗' }
+    } finally {
+      deletingBackup.value = null
+    }
+  }
+
+  /**
+   * 重新生成指定備份的機器碼
+   * @param name 備份名稱
+   * @returns 操作結果
+   * @description Phase 2 Task 1.1: 單一備份機器碼重新生成，包含 30 秒超時保護
+   */
+  const regenerateMachineID = async (name: string): Promise<Result> => {
+    if (!name) {
+      return { success: false, message: '請選擇備份' }
+    }
+
+    regeneratingId.value = name
+    try {
+      const result = await withTimeout(
+        window.go.main.App.RegenerateMachineID(name),
+        OPERATION_TIMEOUT_MS,
+        '重新生成機器碼操作超時'
+      )
+      return result
+    } catch (e: any) {
+      if (e instanceof TimeoutError) {
+        return { success: false, message: e.message }
+      }
+      return { success: false, message: e.message || '重新生成機器碼失敗' }
+    } finally {
+      regeneratingId.value = null
+    }
+  }
+
+
+  // ============================================================================
+  // 篩選方法
+  // ============================================================================
+
+  /**
+   * 設定訂閱篩選
+   * @param value 篩選值
+   */
+  const setFilterSubscription = (value: string): void => {
+    filterSubscription.value = value
+  }
+
+  /**
+   * 設定提供者篩選
+   * @param value 篩選值
+   */
+  const setFilterProvider = (value: string): void => {
+    filterProvider.value = value
+  }
+
+  /**
+   * 設定餘額篩選
+   * @param value 篩選值
+   */
+  const setFilterBalance = (value: string): void => {
+    filterBalance.value = value
+  }
+
+  // ============================================================================
+  // 選擇操作
+  // ============================================================================
+
+  /**
+   * 切換選擇
+   * @param name 備份名稱
+   */
+  const toggleSelect = (name: string): void => {
+    const newSet = new Set(selectedBackups.value)
+    if (newSet.has(name)) {
+      newSet.delete(name)
+    } else {
+      newSet.add(name)
+    }
+    selectedBackups.value = newSet
+  }
+
+  /**
+   * 全選/取消全選
+   */
+  const toggleSelectAll = (): void => {
+    if (selectedBackups.value.size === filteredBackups.value.length) {
+      selectedBackups.value = new Set()
+    } else {
+      selectedBackups.value = new Set(filteredBackups.value.map(b => b.name))
+    }
+  }
+
+  // ============================================================================
+  // 批量操作
+  // ============================================================================
+
+  /**
+   * 批量刪除
+   * @returns BatchResult 包含成功數量和失敗項目
+   */
+  const batchDelete = async (): Promise<BatchResult> => {
+    const result: BatchResult = {
+      success: true,
+      successCount: 0,
+      failedItems: [],
+    }
+    
+    if (selectedBackups.value.size === 0 || batchOperating.value) {
+      return result
+    }
+    
+    batchOperating.value = true
+    try {
+      for (const name of selectedBackups.value) {
+        try {
+          await window.go.main.App.DeleteBackup(name)
+          result.successCount++
+        } catch (e: any) {
+          result.failedItems.push({
+            name,
+            error: e.message || '刪除失敗',
+          })
+        }
+      }
+      result.success = result.failedItems.length === 0
+      selectedBackups.value = new Set()
+      await loadBackups(false)
+    } finally {
+      batchOperating.value = false
+    }
+    return result
+  }
+
+  /**
+   * 批量重新生成機器碼
+   * @returns BatchResult 包含成功數量和失敗項目
+   */
+  const batchRegenerateMachineID = async (): Promise<BatchResult> => {
+    const result: BatchResult = {
+      success: true,
+      successCount: 0,
+      failedItems: [],
+    }
+    
+    if (selectedBackups.value.size === 0 || batchOperating.value) {
+      return result
+    }
+    
+    batchOperating.value = true
+    try {
+      for (const name of selectedBackups.value) {
+        try {
+          await window.go.main.App.RegenerateMachineID(name)
+          result.successCount++
+        } catch (e: any) {
+          result.failedItems.push({
+            name,
+            error: e.message || '重新生成失敗',
+          })
+        }
+      }
+      result.success = result.failedItems.length === 0
+      selectedBackups.value = new Set()
+      await loadBackups(false)
+    } finally {
+      batchOperating.value = false
+    }
+    return result
+  }
+
+  /**
+   * 批量刷新用量
+   * @param isInCooldown 判斷備份是否在冷卻期的函數
+   * @returns BatchResult 包含成功數量、失敗項目和跳過數量
+   * @description 包含全部冷卻期檢查：若所有選中項目都在冷卻期，返回特殊標記且不清空選擇
+   */
+  const batchRefreshUsage = async (isInCooldown: (name: string) => boolean): Promise<BatchResult> => {
+    const result: BatchResult = {
+      success: true,
+      successCount: 0,
+      failedItems: [],
+      skippedCount: 0,
+    }
+    
+    if (selectedBackups.value.size === 0 || batchOperating.value) {
+      return result
+    }
+    
+    // Task 1.5: 檢查是否所有選中項目都在冷卻期
+    const selectedNames = Array.from(selectedBackups.value)
+    const allInCooldown = selectedNames.every(name => isInCooldown(name))
+    
+    if (allInCooldown) {
+      // 返回特殊結果，不清空選擇
+      return {
+        success: false,
+        successCount: 0,
+        failedItems: [],
+        skippedCount: selectedNames.length,
+        allInCooldown: true,
+      }
+    }
+    
+    batchOperating.value = true
+    try {
+      for (const name of selectedBackups.value) {
+        // 跳過冷卻期中的備份
+        if (isInCooldown(name)) {
+          result.skippedCount!++
+          continue
+        }
+        
+        try {
+          await window.go.main.App.RefreshBackupUsage(name)
+          result.successCount++
+        } catch (e: any) {
+          result.failedItems.push({
+            name,
+            error: e.message || '刷新失敗',
+          })
+        }
+      }
+      result.success = result.failedItems.length === 0
+      selectedBackups.value = new Set()
+    } finally {
+      batchOperating.value = false
+    }
+    return result
+  }
+
+
+  // ============================================================================
+  // 返回
+  // ============================================================================
+
+  return {
+    // 狀態
+    backups,
+    currentMachineId,
+    currentEnvironmentName,
+    isLoadingBackups,
+    searchQuery,
+    filterSubscription,
+    filterProvider,
+    filterBalance,
+    selectedBackups,
+    batchOperating,
+    creatingBackup,
+    switchingBackup,
+    deletingBackup,
+    regeneratingId,
+
+    // 計算屬性
+    activeBackup,
+    filteredBackups,
+
+    // 方法
+    loadBackups,
+    loadFullBackupData,
+    createBackup,
+    switchToBackup,
+    deleteBackup,
+    regenerateMachineID,
+    setFilterSubscription,
+    setFilterProvider,
+    setFilterBalance,
+    toggleSelect,
+    toggleSelectAll,
+    batchDelete,
+    batchRegenerateMachineID,
+    batchRefreshUsage,
+  }
+}

--- a/frontend/src/composables/useFolderManagement.ts
+++ b/frontend/src/composables/useFolderManagement.ts
@@ -1,0 +1,458 @@
+/**
+ * useFolderManagement Composable
+ * @description 文件夾管理核心 Composable，負責管理文件夾列表、拖放、重命名等功能
+ * @see App.vue - 原始實作參考
+ */
+import { ref, type Ref } from 'vue'
+import type { FolderItem, BackupItem, Result } from '@/types/backup'
+
+/**
+ * 文件夾管理 Composable 返回類型
+ */
+export interface UseFolderManagementReturn {
+  // 狀態
+  folders: Ref<FolderItem[]>
+  expandedFolders: Ref<Set<string>>
+  uncategorizedExpanded: Ref<boolean>
+  showCreateFolderModal: Ref<boolean>
+  newFolderName: Ref<string>
+  creatingFolder: Ref<boolean>
+  renamingFolder: Ref<string | null>
+  renameFolderName: Ref<string>
+  deletingFolder: Ref<string | null>
+  dragOverFolderId: Ref<string | null>
+  dragOverUncategorized: Ref<boolean>
+  showDeleteFolderDialog: Ref<boolean>
+  folderToDelete: Ref<FolderItem | null>
+  showMoveToFolderDropdown: Ref<boolean>
+
+  // 方法
+  loadFolders: () => Promise<void>
+  createFolder: () => Promise<Result>
+  startRenameFolder: (folder: FolderItem) => void
+  confirmRenameFolder: () => Promise<Result>
+  cancelRenameFolder: () => void
+  deleteFolder: (folder: FolderItem, backupsInFolder: BackupItem[]) => Promise<Result>
+  confirmDeleteFolder: (deleteSnapshots: boolean) => Promise<Result>
+  cancelDeleteFolder: () => void
+  toggleFolder: (folderId: string) => void
+  toggleUncategorized: () => void
+  getBackupsInFolder: (backups: BackupItem[], folderId: string) => BackupItem[]
+  getUncategorizedBackups: (backups: BackupItem[], folders: FolderItem[]) => BackupItem[]
+
+  // 拖放方法
+  onDragEnterFolder: (folderId: string) => void
+  onDragLeaveFolder: () => void
+  onDragEnterUncategorized: () => void
+  onDragLeaveUncategorized: () => void
+  onDropToFolder: (backupNames: string[], folderId: string) => Promise<void>
+  onDropToUncategorized: (backupNames: string[]) => Promise<void>
+  cleanupDragState: () => void
+
+  // 批量操作
+  batchMoveToFolder: (backupNames: string[], folderId: string | null) => Promise<void>
+}
+
+/**
+ * 文件夾管理 Composable
+ * @returns 文件夾管理相關的狀態和方法
+ */
+export function useFolderManagement(): UseFolderManagementReturn {
+  // ============================================================================
+  // 狀態定義
+  // ============================================================================
+
+  /** 文件夾列表 */
+  const folders = ref<FolderItem[]>([])
+
+  /** 展開的文件夾 ID 集合 */
+  const expandedFolders = ref<Set<string>>(new Set())
+
+  /** 未分類區塊是否展開 */
+  const uncategorizedExpanded = ref<boolean>(true)
+
+  /** 是否顯示創建文件夾對話框 */
+  const showCreateFolderModal = ref<boolean>(false)
+
+  /** 新文件夾名稱 */
+  const newFolderName = ref<string>('')
+
+  /** 是否正在創建文件夾 */
+  const creatingFolder = ref<boolean>(false)
+
+  /** 正在重命名的文件夾 ID */
+  const renamingFolder = ref<string | null>(null)
+
+  /** 重命名文件夾的新名稱 */
+  const renameFolderName = ref<string>('')
+
+  /** 正在刪除的文件夾 ID */
+  const deletingFolder = ref<string | null>(null)
+
+  /** 拖放懸停的文件夾 ID */
+  const dragOverFolderId = ref<string | null>(null)
+
+  /** 是否拖放懸停在未分類區塊 */
+  const dragOverUncategorized = ref<boolean>(false)
+
+  /** 是否顯示刪除文件夾對話框 */
+  const showDeleteFolderDialog = ref<boolean>(false)
+
+  /** 待刪除的文件夾 */
+  const folderToDelete = ref<FolderItem | null>(null)
+
+  /** 是否顯示移動到文件夾下拉選單 */
+  const showMoveToFolderDropdown = ref<boolean>(false)
+
+  // ============================================================================
+  // 方法
+  // ============================================================================
+
+  /**
+   * 載入文件夾列表
+   */
+  const loadFolders = async (): Promise<void> => {
+    try {
+      folders.value = await window.go.main.App.GetFolderList() || []
+    } catch (e) {
+      console.error('Failed to load folders:', e)
+    }
+  }
+
+  /**
+   * 創建文件夾
+   * @returns 操作結果
+   */
+  const createFolder = async (): Promise<Result> => {
+    const name = newFolderName.value.trim()
+    if (!name) {
+      return { success: false, message: '文件夾名稱不能為空' }
+    }
+
+    creatingFolder.value = true
+    try {
+      const result = await window.go.main.App.CreateFolder(name)
+      if (result.success) {
+        showCreateFolderModal.value = false
+        newFolderName.value = ''
+        await loadFolders()
+      }
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '創建文件夾失敗' }
+    } finally {
+      creatingFolder.value = false
+    }
+  }
+
+  /**
+   * 開始重命名文件夾
+   * @param folder 要重命名的文件夾
+   */
+  const startRenameFolder = (folder: FolderItem): void => {
+    renamingFolder.value = folder.id
+    renameFolderName.value = folder.name
+  }
+
+  /**
+   * 確認重命名文件夾
+   * @returns 操作結果
+   */
+  const confirmRenameFolder = async (): Promise<Result> => {
+    if (!renamingFolder.value) {
+      return { success: false, message: '沒有正在重命名的文件夾' }
+    }
+
+    const name = renameFolderName.value.trim()
+    if (!name) {
+      return { success: false, message: '文件夾名稱不能為空' }
+    }
+
+    try {
+      const result = await window.go.main.App.RenameFolder(renamingFolder.value, name)
+      if (result.success) {
+        await loadFolders()
+      }
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '重命名文件夾失敗' }
+    } finally {
+      renamingFolder.value = null
+      renameFolderName.value = ''
+    }
+  }
+
+  /**
+   * 取消重命名文件夾
+   */
+  const cancelRenameFolder = (): void => {
+    renamingFolder.value = null
+    renameFolderName.value = ''
+  }
+
+  /**
+   * 刪除文件夾
+   * @param folder 要刪除的文件夾
+   * @param backupsInFolder 文件夾中的備份列表
+   * @returns 操作結果
+   */
+  const deleteFolder = async (folder: FolderItem, backupsInFolder: BackupItem[]): Promise<Result> => {
+    // Property 10: 檢查是否包含當前使用中的快照
+    if (backupsInFolder.some(b => b.isCurrent)) {
+      return { success: false, message: '無法刪除包含當前使用中快照的文件夾' }
+    }
+
+    if (backupsInFolder.length > 0) {
+      // 非空文件夾，顯示專用對話框
+      folderToDelete.value = folder
+      showDeleteFolderDialog.value = true
+      return { success: true, message: '顯示刪除確認對話框' }
+    } else {
+      // 空文件夾，直接刪除
+      deletingFolder.value = folder.id
+      try {
+        const result = await window.go.main.App.DeleteFolder(folder.id, false)
+        if (result.success) {
+          await loadFolders()
+        }
+        return result
+      } catch (e: any) {
+        return { success: false, message: e.message || '刪除文件夾失敗' }
+      } finally {
+        deletingFolder.value = null
+      }
+    }
+  }
+
+  /**
+   * 確認刪除文件夾（處理用戶選擇）
+   * @param deleteSnapshots 是否一併刪除快照
+   * @returns 操作結果
+   */
+  const confirmDeleteFolder = async (deleteSnapshots: boolean): Promise<Result> => {
+    if (!folderToDelete.value) {
+      return { success: false, message: '沒有待刪除的文件夾' }
+    }
+
+    const folder = folderToDelete.value
+    showDeleteFolderDialog.value = false
+    deletingFolder.value = folder.id
+
+    try {
+      const result = await window.go.main.App.DeleteFolder(folder.id, deleteSnapshots)
+      if (result.success) {
+        await loadFolders()
+      }
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '刪除文件夾失敗' }
+    } finally {
+      deletingFolder.value = null
+      folderToDelete.value = null
+    }
+  }
+
+  /**
+   * 取消刪除文件夾對話框
+   */
+  const cancelDeleteFolder = (): void => {
+    showDeleteFolderDialog.value = false
+    folderToDelete.value = null
+  }
+
+  /**
+   * 切換文件夾展開狀態
+   * @param folderId 文件夾 ID
+   */
+  const toggleFolder = (folderId: string): void => {
+    const newSet = new Set(expandedFolders.value)
+    if (newSet.has(folderId)) {
+      newSet.delete(folderId)
+    } else {
+      newSet.add(folderId)
+    }
+    expandedFolders.value = newSet
+  }
+
+  /**
+   * 切換未分類區塊展開狀態
+   */
+  const toggleUncategorized = (): void => {
+    uncategorizedExpanded.value = !uncategorizedExpanded.value
+  }
+
+  /**
+   * 獲取指定文件夾中的備份
+   * @param backups 備份列表
+   * @param folderId 文件夾 ID
+   * @returns 文件夾中的備份列表
+   */
+  const getBackupsInFolder = (backups: BackupItem[], folderId: string): BackupItem[] => {
+    return backups.filter(b => b.folderId === folderId)
+  }
+
+  /**
+   * 獲取未分類的備份（包含孤兒 folderId）
+   * @param backups 備份列表
+   * @param folderList 文件夾列表
+   * @returns 未分類的備份列表
+   */
+  const getUncategorizedBackups = (backups: BackupItem[], folderList: FolderItem[]): BackupItem[] => {
+    const folderIds = new Set(folderList.map(f => f.id))
+    return backups.filter(b => !b.folderId || !folderIds.has(b.folderId))
+  }
+
+  // ============================================================================
+  // 拖放方法
+  // ============================================================================
+
+  /**
+   * 拖放進入文件夾
+   * @param folderId 文件夾 ID
+   */
+  const onDragEnterFolder = (folderId: string): void => {
+    dragOverFolderId.value = folderId
+    dragOverUncategorized.value = false
+  }
+
+  /**
+   * 拖放離開文件夾
+   */
+  const onDragLeaveFolder = (): void => {
+    dragOverFolderId.value = null
+  }
+
+  /**
+   * 拖放進入未分類區塊
+   */
+  const onDragEnterUncategorized = (): void => {
+    dragOverUncategorized.value = true
+    dragOverFolderId.value = null
+  }
+
+  /**
+   * 拖放離開未分類區塊
+   */
+  const onDragLeaveUncategorized = (): void => {
+    dragOverUncategorized.value = false
+  }
+
+  /**
+   * 拖放到文件夾
+   * @param backupNames 備份名稱列表
+   * @param folderId 目標文件夾 ID
+   */
+  const onDropToFolder = async (backupNames: string[], folderId: string): Promise<void> => {
+    dragOverFolderId.value = null
+
+    try {
+      for (const name of backupNames) {
+        await window.go.main.App.AssignSnapshotToFolder(name, folderId)
+      }
+      await loadFolders()
+    } catch (e: any) {
+      console.error('Failed to assign snapshots to folder:', e)
+    }
+  }
+
+  /**
+   * 拖放到未分類區塊
+   * @param backupNames 備份名稱列表
+   */
+  const onDropToUncategorized = async (backupNames: string[]): Promise<void> => {
+    dragOverUncategorized.value = false
+
+    try {
+      for (const name of backupNames) {
+        await window.go.main.App.UnassignSnapshot(name)
+      }
+      await loadFolders()
+    } catch (e: any) {
+      console.error('Failed to unassign snapshots:', e)
+    }
+  }
+
+  /**
+   * 清理拖放狀態（P1: 拖放取消時清理）
+   */
+  const cleanupDragState = (): void => {
+    dragOverFolderId.value = null
+    dragOverUncategorized.value = false
+  }
+
+  // ============================================================================
+  // 批量操作
+  // ============================================================================
+
+  /**
+   * 批量移動到文件夾
+   * @param backupNames 備份名稱列表
+   * @param folderId 目標文件夾 ID（null 表示移到未分類）
+   */
+  const batchMoveToFolder = async (backupNames: string[], folderId: string | null): Promise<void> => {
+    if (backupNames.length === 0) return
+
+    showMoveToFolderDropdown.value = false
+
+    try {
+      for (const name of backupNames) {
+        if (folderId) {
+          await window.go.main.App.AssignSnapshotToFolder(name, folderId)
+        } else {
+          await window.go.main.App.UnassignSnapshot(name)
+        }
+      }
+      await loadFolders()
+    } catch (e: any) {
+      console.error('Failed to batch move to folder:', e)
+    }
+  }
+
+  // ============================================================================
+  // 返回
+  // ============================================================================
+
+  return {
+    // 狀態
+    folders,
+    expandedFolders,
+    uncategorizedExpanded,
+    showCreateFolderModal,
+    newFolderName,
+    creatingFolder,
+    renamingFolder,
+    renameFolderName,
+    deletingFolder,
+    dragOverFolderId,
+    dragOverUncategorized,
+    showDeleteFolderDialog,
+    folderToDelete,
+    showMoveToFolderDropdown,
+
+    // 方法
+    loadFolders,
+    createFolder,
+    startRenameFolder,
+    confirmRenameFolder,
+    cancelRenameFolder,
+    deleteFolder,
+    confirmDeleteFolder,
+    cancelDeleteFolder,
+    toggleFolder,
+    toggleUncategorized,
+    getBackupsInFolder,
+    getUncategorizedBackups,
+
+    // 拖放方法
+    onDragEnterFolder,
+    onDragLeaveFolder,
+    onDragEnterUncategorized,
+    onDragLeaveUncategorized,
+    onDropToFolder,
+    onDropToUncategorized,
+    cleanupDragState,
+
+    // 批量操作
+    batchMoveToFolder,
+  }
+}

--- a/frontend/src/composables/useSoftReset.ts
+++ b/frontend/src/composables/useSoftReset.ts
@@ -1,0 +1,249 @@
+/**
+ * useSoftReset Composable
+ * @description 軟重置核心 Composable，負責管理軟重置、還原原始機器、Extension Patch 等功能
+ * @see App.vue - 原始實作參考
+ */
+import { ref, type Ref } from 'vue'
+import type { SoftResetStatus, Result } from '@/types/backup'
+import { withTimeout, TimeoutError } from '@/utils/withTimeout'
+
+/** 操作超時時間（毫秒） */
+const OPERATION_TIMEOUT_MS = 30000
+
+/**
+ * 軟重置 Composable 返回類型
+ */
+export interface UseSoftResetReturn {
+  // 狀態
+  softResetStatus: Ref<SoftResetStatus>
+  resetting: Ref<boolean>
+  restoringOriginal: Ref<boolean>
+  patching: Ref<boolean>
+  hasUsedReset: Ref<boolean>
+  showFirstTimeResetModal: Ref<boolean>
+
+  // 方法
+  getSoftResetStatus: () => Promise<void>
+  loadHasUsedReset: () => void
+  resetToNew: () => Promise<void>
+  executeReset: () => Promise<Result>
+  confirmFirstTimeReset: () => Promise<void>
+  restoreOriginal: () => Promise<Result>
+  regenerateMachineID: (backupName: string) => Promise<Result>
+  patchExtension: () => Promise<Result>
+
+  // 工具方法
+  openExtensionFolder: () => Promise<void>
+  openMachineIDFolder: () => Promise<void>
+  openSSOCacheFolder: () => Promise<void>
+}
+
+/** localStorage key for hasUsedReset */
+const HAS_USED_RESET_KEY = 'kiro-manager-has-used-reset'
+
+/**
+ * 軟重置 Composable
+ * @returns 軟重置相關的狀態和方法
+ */
+export function useSoftReset(): UseSoftResetReturn {
+  // ============================================================================
+  // 狀態定義
+  // ============================================================================
+
+  /** 軟重置狀態 */
+  const softResetStatus = ref<SoftResetStatus>({
+    isPatched: false,
+    hasCustomId: false,
+    customMachineId: '',
+    extensionPath: '',
+    isSupported: true,
+  })
+
+  /** 一鍵新機進行中狀態 */
+  const resetting = ref<boolean>(false)
+
+  /** 還原原始機器進行中狀態 */
+  const restoringOriginal = ref<boolean>(false)
+
+  /** Extension Patch 進行中狀態 */
+  const patching = ref<boolean>(false)
+
+  /** 是否已使用過一鍵新機 */
+  const hasUsedReset = ref<boolean>(false)
+
+  /** 是否顯示首次使用對話框 */
+  const showFirstTimeResetModal = ref<boolean>(false)
+
+  // ============================================================================
+  // 方法
+  // ============================================================================
+
+  /**
+   * 載入軟重置狀態
+   */
+  const getSoftResetStatus = async (): Promise<void> => {
+    try {
+      softResetStatus.value = await window.go.main.App.GetSoftResetStatus()
+    } catch (e) {
+      console.error('Failed to get soft reset status:', e)
+    }
+  }
+
+  /**
+   * 從 localStorage 載入是否已使用過一鍵新機
+   */
+  const loadHasUsedReset = (): void => {
+    hasUsedReset.value = localStorage.getItem(HAS_USED_RESET_KEY) === 'true'
+  }
+
+  /**
+   * 一鍵新機（檢查是否首次使用）
+   */
+  const resetToNew = async (): Promise<void> => {
+    if (!hasUsedReset.value) {
+      showFirstTimeResetModal.value = true
+      return
+    }
+    // 如果已經使用過，直接執行（實際使用時會有確認對話框）
+    // 這裡不直接執行，讓調用方處理確認邏輯
+  }
+
+  /**
+   * 執行軟重置
+   * @returns 操作結果
+   */
+  const executeReset = async (): Promise<Result> => {
+    resetting.value = true
+    try {
+      const result = await window.go.main.App.SoftResetToNewMachine()
+      if (result.success) {
+        hasUsedReset.value = true
+        localStorage.setItem(HAS_USED_RESET_KEY, 'true')
+      }
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '軟重置失敗' }
+    } finally {
+      resetting.value = false
+    }
+  }
+
+  /**
+   * 確認首次使用軟重置
+   */
+  const confirmFirstTimeReset = async (): Promise<void> => {
+    showFirstTimeResetModal.value = false
+    await executeReset()
+  }
+
+  /**
+   * 還原原始機器
+   * @returns 操作結果
+   */
+  const restoreOriginal = async (): Promise<Result> => {
+    restoringOriginal.value = true
+    try {
+      const result = await window.go.main.App.RestoreSoftReset()
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '還原失敗' }
+    } finally {
+      restoringOriginal.value = false
+    }
+  }
+
+  /**
+   * 重新生成備份的機器碼
+   * @param backupName 備份名稱
+   * @returns 操作結果
+   */
+  const regenerateMachineID = async (backupName: string): Promise<Result> => {
+    try {
+      const result = await window.go.main.App.RegenerateMachineID(backupName)
+      return result
+    } catch (e: any) {
+      return { success: false, message: e.message || '重新生成機器碼失敗' }
+    }
+  }
+
+  /**
+   * 重新 Patch Extension
+   * @returns 操作結果
+   * @description 包含 30 秒超時保護
+   */
+  const patchExtension = async (): Promise<Result> => {
+    patching.value = true
+    try {
+      const result = await withTimeout(
+        window.go.main.App.RepatchExtension(),
+        OPERATION_TIMEOUT_MS,
+        'Patch Extension 操作超時'
+      )
+      if (result.success) {
+        softResetStatus.value = await window.go.main.App.GetSoftResetStatus()
+      }
+      return result
+    } catch (e: any) {
+      if (e instanceof TimeoutError) {
+        return { success: false, message: e.message }
+      }
+      return { success: false, message: e.message || 'Patch 失敗' }
+    } finally {
+      patching.value = false
+    }
+  }
+
+  // ============================================================================
+  // 工具方法
+  // ============================================================================
+
+  /**
+   * 開啟 Extension 資料夾
+   */
+  const openExtensionFolder = async (): Promise<void> => {
+    await window.go.main.App.OpenExtensionFolder()
+  }
+
+  /**
+   * 開啟 Machine ID 資料夾
+   */
+  const openMachineIDFolder = async (): Promise<void> => {
+    await window.go.main.App.OpenMachineIDFolder()
+  }
+
+  /**
+   * 開啟 SSO Cache 資料夾
+   */
+  const openSSOCacheFolder = async (): Promise<void> => {
+    await window.go.main.App.OpenSSOCacheFolder()
+  }
+
+  // ============================================================================
+  // 返回
+  // ============================================================================
+
+  return {
+    // 狀態
+    softResetStatus,
+    resetting,
+    restoringOriginal,
+    patching,
+    hasUsedReset,
+    showFirstTimeResetModal,
+
+    // 方法
+    getSoftResetStatus,
+    loadHasUsedReset,
+    resetToNew,
+    executeReset,
+    confirmFirstTimeReset,
+    restoreOriginal,
+    regenerateMachineID,
+    patchExtension,
+
+    // 工具方法
+    openExtensionFolder,
+    openMachineIDFolder,
+    openSSOCacheFolder,
+  }
+}

--- a/frontend/src/composables/useUIState.ts
+++ b/frontend/src/composables/useUIState.ts
@@ -1,0 +1,229 @@
+import { ref } from 'vue'
+import type {
+  MenuType,
+  ToastType,
+  ToastState,
+  ConfirmDialogState,
+  ConfirmDialogOptions,
+  UIStateReturn
+} from '@/types/ui'
+
+/** Toast 計時器 ID（P1-FIX: 防止計時器累積） */
+let toastTimeoutId: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * UI 狀態管理 Composable
+ * @description 管理應用程式的 UI 狀態，包括菜單、Toast、確認對話框等
+ * @requirements 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 8.2
+ */
+export function useUIState(): UIStateReturn {
+  // ============================================
+  // 狀態定義
+  // ============================================
+  
+  /** 當前活動菜單 */
+  const activeMenu = ref<MenuType>('dashboard')
+  
+  /** 移動端菜單開關狀態 */
+  const isMobileMenuOpen = ref(false)
+  
+  /** 當前開啟的篩選器名稱 */
+  const openFilter = ref<string | null>(null)
+  
+  /** Toast 通知狀態 */
+  const toast = ref<ToastState>({
+    show: false,
+    message: '',
+    type: 'success'
+  })
+  
+  /** 確認對話框狀態 */
+  const confirmDialog = ref<ConfirmDialogState>({
+    show: false,
+    title: '',
+    message: '',
+    type: 'warning',
+    confirmText: '確認',
+    cancelText: '取消',
+    onConfirm: () => {},
+    onCancel: () => {}
+  })
+
+  // ============================================
+  // 菜單相關方法
+  // ============================================
+  
+  /**
+   * 設定活動菜單
+   * @description 切換菜單時自動關閉移動端菜單
+   * @requirements 7.1 - 菜單切換
+   * @param menu 目標菜單
+   */
+  const setActiveMenu = (menu: MenuType): void => {
+    activeMenu.value = menu
+    // Property 28: 菜單切換時關閉移動端菜單
+    isMobileMenuOpen.value = false
+  }
+  
+  /**
+   * 切換移動端菜單
+   * @description 反轉移動端菜單的開關狀態
+   * @requirements 7.2 - 移動端菜單控制
+   */
+  const toggleMobileMenu = (): void => {
+    // Property 11: Toggle 狀態反轉
+    isMobileMenuOpen.value = !isMobileMenuOpen.value
+  }
+
+  // ============================================
+  // 篩選器相關方法
+  // ============================================
+  
+  /**
+   * 切換篩選器
+   * @description 開啟指定篩選器，或關閉已開啟的篩選器
+   * @requirements 7.3 - 篩選器控制
+   * @param name 篩選器名稱
+   */
+  const toggleFilter = (name: string): void => {
+    openFilter.value = openFilter.value === name ? null : name
+  }
+  
+  /**
+   * 關閉所有篩選器
+   * @requirements 7.4 - 篩選器控制
+   */
+  const closeAllFilters = (): void => {
+    openFilter.value = null
+  }
+
+  // ============================================
+  // Toast 相關方法
+  // ============================================
+  
+  /**
+   * 顯示 Toast 通知
+   * @description 顯示 Toast 並在指定時間後自動消失
+   * @requirements 7.5 - Toast 通知
+   * @param message 訊息內容
+   * @param type Toast 類型
+   * @param duration 持續時間（毫秒），預設 3000ms
+   */
+  const showToast = (
+    message: string,
+    type: ToastType,
+    duration: number = 3000
+  ): void => {
+    // P1-FIX: 清除前一個計時器，防止 Toast 提前消失
+    if (toastTimeoutId) {
+      clearTimeout(toastTimeoutId)
+      toastTimeoutId = null
+    }
+    
+    toast.value = { show: true, message, type }
+    // Property 30: Toast 自動消失
+    toastTimeoutId = setTimeout(() => {
+      toast.value.show = false
+      toastTimeoutId = null
+    }, duration)
+  }
+
+  /**
+   * 清理 Toast 計時器
+   * @description 清除 Toast 計時器並隱藏 Toast，用於組件卸載時防止 Memory Leak
+   * @requirements P0-3 - Toast Timer Memory Leak 修復
+   */
+  const cleanupToast = (): void => {
+    if (toastTimeoutId) {
+      clearTimeout(toastTimeoutId)
+      toastTimeoutId = null
+    }
+    toast.value.show = false
+  }
+
+  // ============================================
+  // 確認對話框相關方法
+  // ============================================
+  
+  /**
+   * 顯示確認對話框
+   * @description 顯示確認對話框並返回 Promise
+   * @requirements 7.6 - 確認對話框
+   * @param options 對話框選項
+   * @returns Promise<boolean> - 用戶確認返回 true，取消返回 false
+   */
+  const showConfirmDialog = (options: ConfirmDialogOptions): Promise<boolean> => {
+    return new Promise((resolve) => {
+      // Property 29: 確認對話框 Promise 解析
+      confirmDialog.value = {
+        show: true,
+        title: options.title,
+        message: options.message,
+        type: options.type || 'warning',
+        confirmText: options.confirmText || '確認',
+        cancelText: options.cancelText || '取消',
+        onConfirm: () => {
+          confirmDialog.value.show = false
+          resolve(true)
+        },
+        onCancel: () => {
+          confirmDialog.value.show = false
+          resolve(false)
+        }
+      }
+    })
+  }
+
+  // ============================================
+  // 錯誤處理方法
+  // ============================================
+  
+  /**
+   * 統一錯誤處理
+   * @description 提取錯誤訊息並顯示錯誤 Toast
+   * @requirements 8.2 - 統一錯誤處理
+   * @param error 錯誤物件
+   * @param fallbackMessage 備用訊息
+   */
+  const handleError = (error: unknown, fallbackMessage?: string): void => {
+    // Property 32: 統一錯誤處理
+    let message: string
+    
+    if (error instanceof Error) {
+      message = error.message
+    } else if (typeof error === 'string') {
+      message = error
+    } else if (error && typeof error === 'object' && 'message' in error) {
+      message = String((error as { message: unknown }).message)
+    } else if (fallbackMessage) {
+      message = fallbackMessage
+    } else {
+      message = '發生未知錯誤'
+    }
+    
+    showToast(message, 'error')
+  }
+
+  // ============================================
+  // 返回公開 API
+  // ============================================
+  
+  return {
+    // 狀態
+    activeMenu,
+    isMobileMenuOpen,
+    openFilter,
+    toast,
+    confirmDialog,
+    
+    // 方法
+    setActiveMenu,
+    toggleMobileMenu,
+    toggleFilter,
+    closeAllFilters,
+    showToast,
+    cleanupToast,
+    showConfirmDialog,
+    handleError
+  }
+}

--- a/frontend/src/composables/useUsageRefresh.ts
+++ b/frontend/src/composables/useUsageRefresh.ts
@@ -1,0 +1,282 @@
+import { ref, type Ref } from 'vue'
+import type { Result } from '@/types/backup'
+
+/**
+ * 刷新選項
+ */
+export interface RefreshOptions {
+  onLocalUpdate?: () => void
+}
+
+/**
+ * 用量刷新狀態返回類型
+ */
+export interface UsageRefreshReturn {
+  // 狀態
+  refreshingBackup: Ref<string | null>
+  refreshingCurrent: Ref<boolean>
+  countdownTimers: Ref<Record<string, number>>
+  countdownCurrentAccount: Ref<number>
+  
+  // 方法
+  isInCooldown: (name: string) => boolean
+  isCurrentInCooldown: () => boolean
+  startCountdown: (name: string, seconds: number) => void
+  startCurrentCountdown: (seconds: number) => void
+  clearAllCountdowns: () => void
+  cleanup: () => void  // P0-FIX: Memory Leak 修復
+  
+  // Phase 2 Task 1.3: 擴展方法
+  refreshBackupUsageWithUpdate: (name: string, options: RefreshOptions) => Promise<Result>
+  refreshCurrentUsageWithUpdate: (options: RefreshOptions) => Promise<Result>
+}
+
+/** 預設刷新冷卻期（秒） */
+export const REFRESH_COOLDOWN_SECONDS = 60
+
+/**
+ * 用量刷新管理 Composable
+ * @description 管理備份用量刷新狀態和冷卻期倒計時
+ * @requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7
+ */
+export function useUsageRefresh(): UsageRefreshReturn {
+  // ============================================
+  // 狀態定義
+  // ============================================
+  
+  /** 正在刷新的備份名稱 */
+  const refreshingBackup = ref<string | null>(null)
+  
+  /** 是否正在刷新當前帳號 */
+  const refreshingCurrent = ref(false)
+  
+  /** 各備份的倒計時秒數 */
+  const countdownTimers = ref<Record<string, number>>({})
+  
+  /** 當前帳號的倒計時秒數 */
+  const countdownCurrentAccount = ref(0)
+  
+  // ============================================
+  // Interval 追蹤（Property 16: Interval 累積防護）
+  // ============================================
+  
+  /** 各備份的 interval ID */
+  const countdownIntervals = ref<Record<string, ReturnType<typeof setInterval> | null>>({})
+  
+  /** 當前帳號的 interval ID */
+  let currentAccountInterval: ReturnType<typeof setInterval> | null = null
+
+  // ============================================
+  // 冷卻期檢查方法
+  // ============================================
+  
+  /**
+   * 檢查備份是否在冷卻期
+   * @description Property 15: 冷卻期狀態一致性
+   * @param name 備份名稱
+   * @returns 是否在冷卻期
+   */
+  const isInCooldown = (name: string): boolean => {
+    return (countdownTimers.value[name] ?? 0) > 0
+  }
+  
+  /**
+   * 檢查當前帳號是否在冷卻期
+   * @description Property 15: 冷卻期狀態一致性
+   * @returns 是否在冷卻期
+   */
+  const isCurrentInCooldown = (): boolean => {
+    return countdownCurrentAccount.value > 0
+  }
+
+  // ============================================
+  // 倒計時控制方法
+  // ============================================
+  
+  /**
+   * 開始備份倒計時
+   * @description Property 16: Interval 累積防護 - 清除現有 interval 後再建立新的
+   * @param name 備份名稱
+   * @param seconds 倒計時秒數
+   */
+  const startCountdown = (name: string, seconds: number = REFRESH_COOLDOWN_SECONDS): void => {
+    // Property 16: 清除現有 interval 防止累積
+    if (countdownIntervals.value[name]) {
+      clearInterval(countdownIntervals.value[name]!)
+      countdownIntervals.value[name] = null
+    }
+    
+    // 設定倒計時初始值
+    countdownTimers.value[name] = seconds
+    
+    // 建立新的 interval
+    countdownIntervals.value[name] = setInterval(() => {
+      if (countdownTimers.value[name] > 0) {
+        countdownTimers.value[name]--
+      } else {
+        // 倒計時結束，清除 interval
+        if (countdownIntervals.value[name]) {
+          clearInterval(countdownIntervals.value[name]!)
+          countdownIntervals.value[name] = null
+        }
+      }
+    }, 1000)
+  }
+  
+  /**
+   * 開始當前帳號倒計時
+   * @description Property 16: Interval 累積防護 - 清除現有 interval 後再建立新的
+   * @param seconds 倒計時秒數
+   */
+  const startCurrentCountdown = (seconds: number = REFRESH_COOLDOWN_SECONDS): void => {
+    // Property 16: 清除現有 interval 防止累積
+    if (currentAccountInterval) {
+      clearInterval(currentAccountInterval)
+      currentAccountInterval = null
+    }
+    
+    // 設定倒計時初始值
+    countdownCurrentAccount.value = seconds
+    
+    // 建立新的 interval
+    currentAccountInterval = setInterval(() => {
+      if (countdownCurrentAccount.value > 0) {
+        countdownCurrentAccount.value--
+      } else {
+        // 倒計時結束，清除 interval
+        if (currentAccountInterval) {
+          clearInterval(currentAccountInterval)
+          currentAccountInterval = null
+        }
+      }
+    }, 1000)
+  }
+  
+  /**
+   * 清除所有倒計時
+   * @description 清除所有備份和當前帳號的倒計時及其 interval
+   */
+  const clearAllCountdowns = (): void => {
+    // 清除所有備份的 interval
+    for (const name in countdownIntervals.value) {
+      if (countdownIntervals.value[name]) {
+        clearInterval(countdownIntervals.value[name]!)
+        countdownIntervals.value[name] = null
+      }
+    }
+    
+    // 清除當前帳號的 interval
+    if (currentAccountInterval) {
+      clearInterval(currentAccountInterval)
+      currentAccountInterval = null
+    }
+    
+    // 重置所有倒計時值
+    for (const name in countdownTimers.value) {
+      countdownTimers.value[name] = 0
+    }
+    countdownCurrentAccount.value = 0
+  }
+
+  /**
+   * 清理函數（供組件卸載時調用）
+   * @description P0-FIX: Memory Leak 修復 - 導出 cleanup 函數供外部在 onUnmounted 中調用
+   */
+  const cleanup = (): void => {
+    clearAllCountdowns()
+  }
+
+  // ============================================
+  // Phase 2 Task 1.3: 擴展方法
+  // ============================================
+
+  /**
+   * 刷新備份用量並更新本地狀態
+   * @param name 備份名稱
+   * @param options 選項，包含 onLocalUpdate 回調
+   * @returns 操作結果
+   * @description Phase 2 Task 1.3: 含本地狀態更新回調的刷新方法
+   */
+  const refreshBackupUsageWithUpdate = async (name: string, options: RefreshOptions): Promise<Result> => {
+    const { onLocalUpdate } = options
+    
+    // 檢查冷卻期
+    if (isInCooldown(name)) {
+      return { success: false, message: '備份正在冷卻期中，請稍後再試' }
+    }
+    
+    refreshingBackup.value = name
+    try {
+      await window.go.main.App.RefreshBackupUsage(name)
+      
+      // 成功後啟動冷卻期
+      startCountdown(name, REFRESH_COOLDOWN_SECONDS)
+      
+      // 調用本地更新回調
+      onLocalUpdate?.()
+      
+      return { success: true, message: '刷新成功' }
+    } catch (e: any) {
+      return { success: false, message: e.message || '刷新失敗' }
+    } finally {
+      refreshingBackup.value = null
+    }
+  }
+
+  /**
+   * 刷新當前帳號用量並更新本地狀態
+   * @param options 選項，包含 onLocalUpdate 回調
+   * @returns 操作結果
+   * @description Phase 2 Task 1.3: 含本地狀態更新回調的刷新方法
+   */
+  const refreshCurrentUsageWithUpdate = async (options: RefreshOptions): Promise<Result> => {
+    const { onLocalUpdate } = options
+    
+    // 檢查冷卻期
+    if (isCurrentInCooldown()) {
+      return { success: false, message: '當前帳號正在冷卻期中，請稍後再試' }
+    }
+    
+    refreshingCurrent.value = true
+    try {
+      // 使用 GetCurrentUsageInfo 獲取最新用量資訊
+      await window.go.main.App.GetCurrentUsageInfo()
+      
+      // 成功後啟動冷卻期
+      startCurrentCountdown(REFRESH_COOLDOWN_SECONDS)
+      
+      // 調用本地更新回調
+      onLocalUpdate?.()
+      
+      return { success: true, message: '刷新成功' }
+    } catch (e: any) {
+      return { success: false, message: e.message || '刷新失敗' }
+    } finally {
+      refreshingCurrent.value = false
+    }
+  }
+
+  // ============================================
+  // 返回公開 API
+  // ============================================
+  
+  return {
+    // 狀態
+    refreshingBackup,
+    refreshingCurrent,
+    countdownTimers,
+    countdownCurrentAccount,
+    
+    // 方法
+    isInCooldown,
+    isCurrentInCooldown,
+    startCountdown,
+    startCurrentCountdown,
+    clearAllCountdowns,
+    cleanup,  // P0-FIX: 導出 cleanup 函數
+    
+    // Phase 2 Task 1.3: 擴展方法
+    refreshBackupUsageWithUpdate,
+    refreshCurrentUsageWithUpdate,
+  }
+}

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -26,7 +26,7 @@ export default {
   app: {
     title: 'Kiro 账号管理器',
     name: 'Kiro 账号管理器',
-    version: 'v0.6.0',
+    version: 'v0.6.1',
     systemReady: '准备就绪',
     online: 'ONLINE',
     processing: '处理中...',
@@ -96,6 +96,8 @@ export default {
     regenerateAll: '批量刷新机器码',
     moveToFolder: '移动到文件夹',
     moveSuccess: '已成功移动 {count} 个快照',
+    partialSuccess: '部分成功，{failed} 项失败',
+    allFailed: '操作失败',
   },
   restore: {
     original: '还原出厂',
@@ -162,6 +164,7 @@ export default {
   },
   message: {
     success: '操作成功',
+    operationTimeout: '操作超时，请稍后再试',
     confirmSwitch: '确定要切换到 {name} 吗？',
     confirmRestore: '警告：这将还原至原始状态，确定吗？',
     confirmReset: '警告：这将生成全新机器指纹并重置环境，确定吗？',

--- a/frontend/src/i18n/zh-TW.ts
+++ b/frontend/src/i18n/zh-TW.ts
@@ -26,7 +26,7 @@ export default {
   app: {
     title: 'Kiro 帳號管理器',
     name: 'Kiro 帳號管理器',
-    version: 'v0.6.0',
+    version: 'v0.6.1',
     systemReady: '準備就緒',
     online: 'ONLINE',
     processing: '處理中...',
@@ -96,6 +96,8 @@ export default {
     regenerateAll: '批量刷新機器碼',
     moveToFolder: '移動到文件夾',
     moveSuccess: '已成功移動 {count} 個快照',
+    partialSuccess: '部分成功，{failed} 項失敗',
+    allFailed: '操作失敗',
   },
   restore: {
     original: '還原出廠',
@@ -162,6 +164,7 @@ export default {
   },
   message: {
     success: '操作成功',
+    operationTimeout: '操作超時，請稍後再試',
     confirmSwitch: '確定要切換到 {name} 嗎？',
     confirmRestore: '警告：這將還原至原始狀態，確定嗎？',
     confirmReset: '警告：這將生成全新機器指紋並重置環境，確定嗎？',

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,4 +3,7 @@ import App from './App.vue'
 import i18n from './i18n'
 import './style.css'
 
+// 導入 NumberFlow 以確保 Web Component 被註冊
+import '@number-flow/vue'
+
 createApp(App).use(i18n).mount('#app')

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -139,3 +139,16 @@
 .animate-pulse-fast {
   animation: pulse-fast 0.3s ease-in-out infinite;
 }
+
+/* NumberFlow 數字動畫樣式 */
+number-flow-vue {
+  display: inline-block;
+  --number-flow-char-height: 1em;
+  --number-flow-mask-height: 0.15em;
+  --number-flow-mask-width: 0.25em;
+}
+
+/* 確保 NumberFlow 內部元素可見 */
+number-flow-vue::part(container) {
+  display: inline-flex;
+}

--- a/frontend/src/types/backup.ts
+++ b/frontend/src/types/backup.ts
@@ -1,0 +1,204 @@
+/**
+ * 備份相關類型定義
+ * @description 從 App.vue 提取的核心介面，用於備份管理功能
+ * @see frontend/wailsjs/go/models.ts - Wails 自動生成的類型（作為參考）
+ */
+
+/**
+ * 備份項目
+ * @description 代表一個快照備份的完整資訊
+ */
+export interface BackupItem {
+  /** 快照名稱 */
+  name: string
+  /** 備份時間 (RFC3339 格式) */
+  backupTime: string
+  /** 是否有 Token */
+  hasToken: boolean
+  /** 是否有 Machine ID */
+  hasMachineId: boolean
+  /** Machine ID 值 */
+  machineId: string
+  /** 認證提供者 (如 'aws', 'github') */
+  provider: string
+  /** 是否為當前使用中的快照 */
+  isCurrent: boolean
+  /** Machine ID 是否與原始機器相同 */
+  isOriginalMachine: boolean
+  /** Token 是否已過期 */
+  isTokenExpired: boolean
+  /** 訂閱類型名稱 */
+  subscriptionTitle: string
+  /** 總額度 */
+  usageLimit: number
+  /** 已使用額度 */
+  currentUsage: number
+  /** 餘額 */
+  balance: number
+  /** 是否為低餘額狀態 */
+  isLowBalance: boolean
+  /** 快取時間 (RFC3339 格式) */
+  cachedAt: string
+  /** 所屬文件夾 ID */
+  folderId: string
+}
+
+/**
+ * 文件夾項目
+ * @description 代表一個快照分類文件夾
+ */
+export interface FolderItem {
+  /** 唯一識別碼 */
+  id: string
+  /** 文件夾名稱 */
+  name: string
+  /** 建立時間 (RFC3339 格式) */
+  createdAt: string
+  /** 排序順序 */
+  order: number
+  /** 包含的快照數量 */
+  snapshotCount: number
+}
+
+/**
+ * 操作結果
+ * @description 通用的操作結果結構
+ */
+export interface Result {
+  /** 操作是否成功 */
+  success: boolean
+  /** 結果訊息 */
+  message: string
+}
+
+/**
+ * 當前用量資訊
+ * @description 當前帳號的用量統計
+ */
+export interface CurrentUsageInfo {
+  /** 訂閱類型名稱 */
+  subscriptionTitle: string
+  /** 總額度 */
+  usageLimit: number
+  /** 已使用額度 */
+  currentUsage: number
+  /** 餘額 */
+  balance: number
+  /** 是否為低餘額狀態 */
+  isLowBalance: boolean
+}
+
+/**
+ * 應用設定
+ * @description 應用程式的全域設定
+ */
+export interface AppSettings {
+  /** 低餘額閾值 (0.0 ~ 1.0) */
+  lowBalanceThreshold: number
+  /** Kiro IDE 版本號 */
+  kiroVersion: string
+  /** 是否使用自動偵測版本號 */
+  useAutoDetect: boolean
+  /** 自定義 Kiro 安裝路徑 */
+  customKiroInstallPath: string
+}
+
+/**
+ * 刷新間隔規則
+ * @description 定義特定餘額範圍內的監控間隔
+ */
+export interface RefreshIntervalRule {
+  /** 餘額下限 */
+  minBalance: number
+  /** 餘額上限 */
+  maxBalance: number
+  /** 刷新間隔 (分鐘) */
+  interval: number
+}
+
+/**
+ * 自動切換設定
+ * @description 自動切換功能的完整設定
+ */
+export interface AutoSwitchSettings {
+  /** 是否啟用自動切換 */
+  enabled: boolean
+  /** 觸發切換的餘額閾值 */
+  balanceThreshold: number
+  /** 目標快照的最低餘額要求 */
+  minTargetBalance: number
+  /** 允許切換的文件夾 ID 列表 */
+  folderIds: string[]
+  /** 允許切換的訂閱類型列表 */
+  subscriptionTypes: string[]
+  /** 刷新間隔規則列表 */
+  refreshIntervals: RefreshIntervalRule[]
+  /** 切換時是否通知 */
+  notifyOnSwitch: boolean
+  /** 低餘額時是否通知 */
+  notifyOnLowBalance: boolean
+}
+
+/**
+ * 自動切換狀態
+ * @description 自動切換監控器的當前狀態
+ */
+export interface AutoSwitchStatus {
+  /** 狀態 ('stopped' | 'running' | 'cooldown') */
+  status: 'stopped' | 'running' | 'cooldown'
+  /** 最後檢測的餘額 */
+  lastBalance: number
+  /** 冷卻剩餘時間 (秒) */
+  cooldownRemaining: number
+  /** 已切換次數 */
+  switchCount: number
+}
+
+/**
+ * 路徑偵測結果
+ * @description Kiro 安裝路徑偵測的結果
+ */
+export interface PathDetectionResult {
+  /** 偵測到的路徑 */
+  path: string
+  /** 偵測是否成功 */
+  success: boolean
+  /** 嘗試過的策略列表 */
+  triedStrategies?: string[]
+  /** 各策略的失敗原因 */
+  failureReasons?: Record<string, string>
+}
+
+/**
+ * 軟重置狀態
+ * @description 軟重置功能的當前狀態
+ */
+export interface SoftResetStatus {
+  /** Extension 是否已 Patch */
+  isPatched: boolean
+  /** 是否有自定義機器碼 */
+  hasCustomId: boolean
+  /** 自定義機器碼值 */
+  customMachineId: string
+  /** Extension 路徑 */
+  extensionPath: string
+  /** 是否支援軟重置 */
+  isSupported: boolean
+}
+
+/**
+ * 批量操作結果
+ * @description 批量操作的詳細結果，包含成功/失敗/跳過的項目統計
+ */
+export interface BatchResult {
+  /** 整體操作是否成功（無失敗項目時為 true） */
+  success: boolean
+  /** 成功處理的項目數量 */
+  successCount: number
+  /** 失敗的項目列表 */
+  failedItems: Array<{ name: string; error: string }>
+  /** 跳過的項目數量（用於 batchRefreshUsage 的冷卻期項目） */
+  skippedCount?: number
+  /** 是否所有選中項目都在冷卻期（用於 batchRefreshUsage） */
+  allInCooldown?: boolean
+}

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -1,0 +1,91 @@
+/**
+ * UI 狀態相關類型定義
+ * @description 用於 useUIState composable
+ */
+
+/** 菜單類型 */
+export type MenuType = 'dashboard' | 'settings' | 'oauth'
+
+/** Toast 類型 */
+export type ToastType = 'success' | 'error' | 'warning'
+
+/** 確認對話框類型 */
+export type ConfirmDialogType = 'warning' | 'danger' | 'info'
+
+/** Toast 狀態 */
+export interface ToastState {
+  show: boolean
+  message: string
+  type: ToastType
+}
+
+/** 確認對話框狀態 */
+export interface ConfirmDialogState {
+  show: boolean
+  title: string
+  message: string
+  type: ConfirmDialogType
+  confirmText: string
+  cancelText: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/** 確認對話框選項 */
+export interface ConfirmDialogOptions {
+  title: string
+  message: string
+  type?: ConfirmDialogType
+  confirmText?: string
+  cancelText?: string
+}
+
+// ============================================================================
+// 自動切換事件類型
+// ============================================================================
+
+/** 自動切換事件類型 */
+export type AutoSwitchEventType = 
+  | 'switch'
+  | 'switch_fail'
+  | 'low_balance'
+  | 'cooldown'
+  | 'max_switch'
+  | 'no_candidates'
+
+/** 自動切換事件資料 */
+export interface AutoSwitchEventData {
+  from?: string
+  to?: string
+}
+
+/** 自動切換事件 */
+export interface AutoSwitchEvent {
+  Type: AutoSwitchEventType
+  Message?: string
+  Data?: AutoSwitchEventData
+}
+
+// ============================================================================
+// useUIState 類型
+// ============================================================================
+
+/** useUIState 返回類型 */
+export interface UIStateReturn {
+  // 狀態
+  activeMenu: import('vue').Ref<MenuType>
+  isMobileMenuOpen: import('vue').Ref<boolean>
+  openFilter: import('vue').Ref<string | null>
+  toast: import('vue').Ref<ToastState>
+  confirmDialog: import('vue').Ref<ConfirmDialogState>
+  
+  // 方法
+  setActiveMenu: (menu: MenuType) => void
+  toggleMobileMenu: () => void
+  toggleFilter: (name: string) => void
+  closeAllFilters: () => void
+  showToast: (message: string, type: ToastType, duration?: number) => void
+  cleanupToast: () => void
+  showConfirmDialog: (options: ConfirmDialogOptions) => Promise<boolean>
+  handleError: (error: unknown, fallbackMessage?: string) => void
+}

--- a/frontend/src/utils/__tests__/machineId.spec.ts
+++ b/frontend/src/utils/__tests__/machineId.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import { truncateMachineId } from '../machineId'
+
+describe('Feature: ui-component-extraction, utils/machineId', () => {
+  // ============================================================================
+  // Property Tests: truncateMachineId
+  // Validates: Requirements 6.1
+  // ============================================================================
+
+  describe('Property: truncateMachineId 一致性', () => {
+    it('should return consistent result for same input', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 0, maxLength: 100 }),
+          fc.integer({ min: 1, max: 20 }),
+          (machineId, length) => {
+            const result1 = truncateMachineId(machineId, length)
+            const result2 = truncateMachineId(machineId, length)
+            return result1 === result2
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it('should never return string longer than length + 3 (for "...")', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 1, maxLength: 100 }),
+          fc.integer({ min: 1, max: 20 }),
+          (machineId, length) => {
+            const result = truncateMachineId(machineId, length)
+            // 結果長度應該 <= length + 3 (加上 "...")
+            return result.length <= length + 3
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it('should return original string if shorter than or equal to length', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 1, maxLength: 10 }),
+          (machineId) => {
+            const length = machineId.length + 5 // 確保 length > machineId.length
+            const result = truncateMachineId(machineId, length)
+            return result === machineId
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Unit Tests: truncateMachineId
+  // ============================================================================
+
+  describe('truncateMachineId', () => {
+    it('should return empty string for empty input', () => {
+      expect(truncateMachineId('')).toBe('')
+    })
+
+    it('should return empty string for null/undefined', () => {
+      expect(truncateMachineId(null as any)).toBe('')
+      expect(truncateMachineId(undefined as any)).toBe('')
+    })
+
+    it('should return original string if shorter than default length (8)', () => {
+      expect(truncateMachineId('abc')).toBe('abc')
+      expect(truncateMachineId('12345678')).toBe('12345678')
+    })
+
+    it('should truncate and add ellipsis if longer than default length', () => {
+      expect(truncateMachineId('123456789')).toBe('12345678...')
+      expect(truncateMachineId('abcdefghijklmnop')).toBe('abcdefgh...')
+    })
+
+    it('should respect custom length parameter', () => {
+      expect(truncateMachineId('abcdefghij', 5)).toBe('abcde...')
+      expect(truncateMachineId('abcdefghij', 10)).toBe('abcdefghij')
+      expect(truncateMachineId('abcdefghij', 15)).toBe('abcdefghij')
+    })
+
+    it('should handle typical machine ID format', () => {
+      const machineId = 'fbc2127b1dfba39ceea01d5d988149a3f105220213636d9f1dfc226c40aa8c12'
+      const result = truncateMachineId(machineId)
+      expect(result).toBe('fbc2127b...')
+      expect(result.length).toBe(11) // 8 + 3 for "..."
+    })
+
+    it('should handle UUID-like format', () => {
+      const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+      const result = truncateMachineId(uuid, 13)
+      expect(result).toBe('a1b2c3d4-e5f6...')
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/subscription.spec.ts
+++ b/frontend/src/utils/__tests__/subscription.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import {
+  subscriptionColorMap,
+  getSubscriptionColorClass,
+  getSubscriptionShortName,
+} from '../subscription'
+
+describe('Feature: ui-component-extraction, utils/subscription', () => {
+  // ============================================================================
+  // Property 2: 訂閱類型顏色映射一致性
+  // Validates: Requirements 6.2
+  // ============================================================================
+
+  describe('Property 2: 訂閱類型顏色映射一致性', () => {
+    it('should return consistent color class for same subscription type', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom('KIRO FREE', 'KIRO PRO', 'KIRO PRO+', 'KIRO POWER'),
+          (subscriptionType) => {
+            const result1 = getSubscriptionColorClass(subscriptionType)
+            const result2 = getSubscriptionColorClass(subscriptionType)
+            return result1 === result2 && typeof result1 === 'string'
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it('should return default color for unknown subscription types', () => {
+      fc.assert(
+        fc.property(
+          fc.string().filter(s => !['KIRO FREE', 'KIRO PRO', 'KIRO PRO+', 'KIRO POWER'].includes(s.toUpperCase())),
+          (unknownType) => {
+            const result = getSubscriptionColorClass(unknownType)
+            // 應返回預設顏色類別
+            return typeof result === 'string' && result.includes('bg-zinc-500')
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('should handle case-insensitive input', () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom('kiro free', 'Kiro Pro', 'KIRO PRO+', 'kiro power'),
+          (subscriptionType) => {
+            const result = getSubscriptionColorClass(subscriptionType)
+            return typeof result === 'string' && result.length > 0
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+  })
+
+  // ============================================================================
+  // Unit Tests: subscriptionColorMap
+  // ============================================================================
+
+  describe('subscriptionColorMap', () => {
+    it('should have correct color for KIRO FREE', () => {
+      expect(subscriptionColorMap['KIRO FREE']).toContain('bg-zinc-500')
+    })
+
+    it('should have correct color for KIRO PRO', () => {
+      expect(subscriptionColorMap['KIRO PRO']).toContain('bg-blue-500')
+    })
+
+    it('should have correct color for KIRO PRO+', () => {
+      expect(subscriptionColorMap['KIRO PRO+']).toContain('bg-violet-500')
+    })
+
+    it('should have correct color for KIRO POWER', () => {
+      expect(subscriptionColorMap['KIRO POWER']).toContain('bg-amber-500')
+    })
+  })
+
+  // ============================================================================
+  // Unit Tests: getSubscriptionColorClass
+  // ============================================================================
+
+  describe('getSubscriptionColorClass', () => {
+    it('should return correct class for each subscription type', () => {
+      expect(getSubscriptionColorClass('KIRO FREE')).toContain('bg-zinc-500')
+      expect(getSubscriptionColorClass('KIRO PRO')).toContain('bg-blue-500')
+      expect(getSubscriptionColorClass('KIRO PRO+')).toContain('bg-violet-500')
+      expect(getSubscriptionColorClass('KIRO POWER')).toContain('bg-amber-500')
+    })
+
+    it('should return default class for empty string', () => {
+      expect(getSubscriptionColorClass('')).toContain('bg-zinc-500')
+    })
+
+    it('should return default class for null/undefined', () => {
+      expect(getSubscriptionColorClass(null as any)).toContain('bg-zinc-500')
+      expect(getSubscriptionColorClass(undefined as any)).toContain('bg-zinc-500')
+    })
+
+    it('should handle lowercase input', () => {
+      expect(getSubscriptionColorClass('kiro free')).toContain('bg-zinc-500')
+      expect(getSubscriptionColorClass('kiro pro')).toContain('bg-blue-500')
+    })
+  })
+
+  // ============================================================================
+  // Unit Tests: getSubscriptionShortName
+  // ============================================================================
+
+  describe('getSubscriptionShortName', () => {
+    it('should return correct short name for each subscription type', () => {
+      expect(getSubscriptionShortName('KIRO FREE')).toBe('FREE')
+      expect(getSubscriptionShortName('KIRO PRO')).toBe('PRO')
+      expect(getSubscriptionShortName('KIRO PRO+')).toBe('PRO+')
+      expect(getSubscriptionShortName('KIRO POWER')).toBe('POWER')
+    })
+
+    it('should return empty string for empty input', () => {
+      expect(getSubscriptionShortName('')).toBe('')
+    })
+
+    it('should return empty string for null/undefined', () => {
+      expect(getSubscriptionShortName(null as any)).toBe('')
+      expect(getSubscriptionShortName(undefined as any)).toBe('')
+    })
+
+    it('should handle lowercase input', () => {
+      expect(getSubscriptionShortName('kiro free')).toBe('FREE')
+      expect(getSubscriptionShortName('kiro pro')).toBe('PRO')
+    })
+
+    it('should return original string if not a known type', () => {
+      expect(getSubscriptionShortName('UNKNOWN')).toBe('UNKNOWN')
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/withTimeout.spec.ts
+++ b/frontend/src/utils/__tests__/withTimeout.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fc from 'fast-check'
+import { withTimeout, TimeoutError } from '../withTimeout'
+
+describe('Feature: app-vue-decoupling, withTimeout utility', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ============================================================================
+  // Property 33: 操作超時保護
+  // Validates: Requirements 8.4
+  // ============================================================================
+
+  describe('Property 33: 操作超時保護', () => {
+    it('正常完成的操作應返回結果', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.anything(),
+          fc.integer({ min: 100, max: 1000 }),
+          async (expectedResult, timeoutMs) => {
+            // 建立一個立即完成的 Promise
+            const operation = Promise.resolve(expectedResult)
+            
+            const result = await withTimeout(operation, timeoutMs)
+            
+            return result === expectedResult
+          }
+        ),
+        { numRuns: 50 }
+      )
+    })
+
+    it('超時的操作應拋出 TimeoutError', async () => {
+      const slowOperation = new Promise((resolve) => {
+        setTimeout(() => resolve('completed'), 5000)
+      })
+      
+      const promise = withTimeout(slowOperation, 1000)
+      
+      // 快進超過超時時間
+      vi.advanceTimersByTime(1001)
+      
+      await expect(promise).rejects.toThrow(TimeoutError)
+    })
+
+    it('超時錯誤應包含自定義訊息', async () => {
+      const slowOperation = new Promise((resolve) => {
+        setTimeout(() => resolve('completed'), 5000)
+      })
+      
+      const customMessage = '操作超時，請稍後重試'
+      const promise = withTimeout(slowOperation, 1000, customMessage)
+      
+      vi.advanceTimersByTime(1001)
+      
+      await expect(promise).rejects.toThrow(customMessage)
+    })
+
+    it('操作在超時前完成應取消超時計時器', async () => {
+      const fastOperation = Promise.resolve('fast result')
+      
+      const result = await withTimeout(fastOperation, 5000)
+      
+      expect(result).toBe('fast result')
+      
+      // 快進超過超時時間，不應有任何錯誤
+      vi.advanceTimersByTime(6000)
+    })
+
+    it('操作拋出的錯誤應正常傳播', async () => {
+      const errorMessage = 'Operation failed'
+      const failingOperation = Promise.reject(new Error(errorMessage))
+      
+      await expect(withTimeout(failingOperation, 5000)).rejects.toThrow(errorMessage)
+    })
+
+    it('超時時間為 0 應立即超時', async () => {
+      const operation = new Promise((resolve) => {
+        setTimeout(() => resolve('completed'), 100)
+      })
+      
+      const promise = withTimeout(operation, 0)
+      
+      vi.advanceTimersByTime(1)
+      
+      await expect(promise).rejects.toThrow(TimeoutError)
+    })
+
+    it('負數超時時間應立即超時', async () => {
+      const operation = new Promise((resolve) => {
+        setTimeout(() => resolve('completed'), 100)
+      })
+      
+      const promise = withTimeout(operation, -100)
+      
+      vi.advanceTimersByTime(1)
+      
+      await expect(promise).rejects.toThrow(TimeoutError)
+    })
+
+    it('TimeoutError 應是 Error 的實例', () => {
+      const error = new TimeoutError('test')
+      expect(error).toBeInstanceOf(Error)
+      expect(error.name).toBe('TimeoutError')
+    })
+
+    it('withTimeout 應保持 Promise 的類型', async () => {
+      interface TestResult {
+        id: number
+        name: string
+      }
+      
+      const typedOperation: Promise<TestResult> = Promise.resolve({
+        id: 1,
+        name: 'test'
+      })
+      
+      const result = await withTimeout(typedOperation, 1000)
+      
+      expect(result.id).toBe(1)
+      expect(result.name).toBe('test')
+    })
+  })
+
+  describe('邊界情況', () => {
+    it('非常大的超時值應正常工作', async () => {
+      const operation = Promise.resolve('result')
+      const result = await withTimeout(operation, Number.MAX_SAFE_INTEGER)
+      expect(result).toBe('result')
+    })
+
+    it('void 返回類型的操作應正常工作', async () => {
+      const voidOperation: Promise<void> = Promise.resolve()
+      const result = await withTimeout(voidOperation, 1000)
+      expect(result).toBeUndefined()
+    })
+
+    it('null 返回值應正常傳遞', async () => {
+      const nullOperation: Promise<null> = Promise.resolve(null)
+      const result = await withTimeout(nullOperation, 1000)
+      expect(result).toBeNull()
+    })
+
+    it('undefined 返回值應正常傳遞', async () => {
+      const undefinedOperation: Promise<undefined> = Promise.resolve(undefined)
+      const result = await withTimeout(undefinedOperation, 1000)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('預設超時訊息', () => {
+    it('未提供自定義訊息時應使用預設訊息', async () => {
+      const slowOperation = new Promise((resolve) => {
+        setTimeout(() => resolve('completed'), 5000)
+      })
+      
+      const promise = withTimeout(slowOperation, 1000)
+      
+      vi.advanceTimersByTime(1001)
+      
+      try {
+        await promise
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(TimeoutError)
+        expect((error as TimeoutError).message).toBeTruthy()
+      }
+    })
+  })
+})

--- a/frontend/src/utils/machineId.ts
+++ b/frontend/src/utils/machineId.ts
@@ -1,0 +1,17 @@
+/**
+ * 機器碼工具函數
+ * @description 提供機器碼相關的格式化函數
+ * @requirements 6.1 - 機器碼顯示
+ */
+
+/**
+ * 截斷機器碼顯示
+ * @param machineId 完整機器碼
+ * @param length 顯示長度（預設 8）
+ * @returns 截斷後的機器碼
+ */
+export function truncateMachineId(machineId: string, length: number = 8): string {
+  if (!machineId) return ''
+  if (machineId.length <= length) return machineId
+  return machineId.substring(0, length) + '...'
+}

--- a/frontend/src/utils/subscription.ts
+++ b/frontend/src/utils/subscription.ts
@@ -1,0 +1,37 @@
+/**
+ * 訂閱類型工具函數
+ * @description 提供訂閱類型相關的顏色映射和格式化函數
+ * @requirements 6.2 - 訂閱類型顏色映射
+ */
+
+/**
+ * 訂閱類型顏色映射
+ * @description 將訂閱類型映射到對應的 Tailwind CSS 類別
+ */
+export const subscriptionColorMap: Record<string, string> = {
+  'KIRO FREE': 'bg-zinc-500/20 text-zinc-400 border border-zinc-500/30',
+  'KIRO PRO': 'bg-blue-500/20 text-blue-400 border border-blue-500/30',
+  'KIRO PRO+': 'bg-violet-500/20 text-violet-400 border border-violet-500/30',
+  'KIRO POWER': 'bg-amber-500/20 text-amber-400 border border-amber-500/30',
+}
+
+/**
+ * 獲取訂閱類型的顏色類別
+ * @param subscriptionTitle 訂閱類型標題
+ * @returns Tailwind CSS 類別字串
+ */
+export function getSubscriptionColorClass(subscriptionTitle: string): string {
+  const upperTitle = subscriptionTitle?.toUpperCase() || ''
+  return subscriptionColorMap[upperTitle] || 'bg-zinc-500/20 text-zinc-400 border border-zinc-500/30'
+}
+
+/**
+ * 獲取訂閱類型的簡稱
+ * @param subscriptionTitle 訂閱類型標題
+ * @returns 簡稱字串
+ */
+export function getSubscriptionShortName(subscriptionTitle: string): string {
+  if (!subscriptionTitle) return ''
+  const upperTitle = subscriptionTitle.toUpperCase()
+  return upperTitle.replace(/^KIRO\s+/, '')
+}

--- a/frontend/src/utils/withTimeout.ts
+++ b/frontend/src/utils/withTimeout.ts
@@ -1,0 +1,48 @@
+/**
+ * 超時錯誤類別
+ * @description 當操作超過指定時間未完成時拋出
+ * @requirements 8.4 - 操作超時保護
+ */
+export class TimeoutError extends Error {
+  constructor(message: string = '操作超時') {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
+
+/**
+ * 為 Promise 添加超時保護
+ * @description 如果操作在指定時間內未完成，將拋出 TimeoutError
+ * @requirements 8.4 - 操作超時保護
+ * @param promise 要執行的 Promise
+ * @param timeoutMs 超時時間（毫秒）
+ * @param message 超時錯誤訊息
+ * @returns Promise<T> - 原始 Promise 的結果或超時錯誤
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message?: string
+): Promise<T> {
+  // 處理 0 或負數超時時間 - 立即超時
+  if (timeoutMs <= 0) {
+    throw new TimeoutError(message || '操作超時')
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new TimeoutError(message || '操作超時'))
+    }, timeoutMs)
+  })
+
+  try {
+    const result = await Promise.race([promise, timeoutPromise])
+    return result
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId)
+    }
+  }
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,3 +5,24 @@ declare module '*.vue' {
   const component: DefineComponent<{}, {}, any>
   export default component
 }
+
+// Wails runtime bindings
+import type * as WailsApp from '../wailsjs/go/main/App'
+import type { main, kiroprocess } from '../wailsjs/go/models'
+
+interface WailsRuntime {
+  EventsOn(eventName: string, callback: (...data: unknown[]) => void): () => void
+  EventsOff(eventName: string): void
+  EventsEmit(eventName: string, ...data: unknown[]): void
+}
+
+declare global {
+  interface Window {
+    go: {
+      main: {
+        App: typeof WailsApp
+      }
+    }
+    runtime: WailsRuntime
+  }
+}


### PR DESCRIPTION
## Summary
將 App.vue 的龐大邏輯拆分為多個獨立的 composables，提升程式碼可維護性與可測試性。

## Changes
### 新增 Composables
- useAppSettings.ts - 應用程式設定管理
- useAutoSwitch.ts - 自動切換邏輯
- useBackupManagement.ts - 備份管理
- useFolderManagement.ts - 資料夾管理
- useSoftReset.ts - 軟重置功能
- useUIState.ts - UI 狀態管理
- useUsageRefresh.ts - 使用量刷新

### 新增 Vue 組件
- BackupCard.vue - 備份卡片
- CurrentStatusCard.vue - 當前狀態卡片
- FolderTree.vue - 資料夾樹狀結構
- NumberFlow.vue - 數字動畫組件
- NumberInput.vue - 數字輸入組件
- SoftResetCard.vue - 軟重置卡片

### 測試覆蓋
- 新增完整的單元測試
- 新增 property-based 測試
- 新增測試用 arbitraries

### 其他改進
- 更新 i18n 翻譯檔案
- 改善型別定義
- 優化程式碼結構
